### PR TITLE
build: pin rsession and re-add powerline

### DIFF
--- a/docker/bioc3_10/Dockerfile
+++ b/docker/bioc3_10/Dockerfile
@@ -93,7 +93,7 @@ RUN python3 -m pip install -U pip && \
     jupyter labextension update @jupyterlab/hub-extension --no-build && \
     jupyter labextension install @jupyterlab/git --no-build && \
     jupyter labextension list && \
-    pip install jupyter-rsession-proxy && \
+    pip install jupyter-rsession-proxy==1.1 && \
     pip install jupyterlab-git && \
     jupyter serverextension enable --py jupyterlab_git && \
     jupyter lab build
@@ -109,6 +109,21 @@ RUN python3 -m pip install "pipx>=0.15.0.0" && \
     pipx install ${RENKU_PIP_SPEC} --pip-args="--pre" && \
     pipx inject renku sentry-sdk && \
     pipx ensurepath
+
+# configure powerline
+COPY powerline.bashrc /tmp/powerline.bashrc
+COPY powerline.config /tmp/powerline.config
+
+RUN cat /tmp/powerline.bashrc >> ~/.bashrc && \
+    pip install powerline-shell && \
+    mkdir -p ~/.config/powerline-shell/ && \
+    cat /tmp/powerline.config >> ~/.config/powerline-shell/config.json
+
+# Add user `rstudio` to sudoers (passwordless)
+USER root
+RUN echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+    rm -rf /wheels
+USER $NB_USER
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/tini", "--", "/entrypoint.sh" ]

--- a/docker/r3.6.1/Dockerfile
+++ b/docker/r3.6.1/Dockerfile
@@ -88,7 +88,7 @@ RUN jupyter notebook --generate-config && \
     pip install -U --no-cache-dir pip wheel
 
 RUN pip install --no-cache-dir \
-        jupyter-rsession-proxy \
+        jupyter-rsession-proxy==1.1 \
         jupyterlab-git && \
     jupyter labextension install @jupyterlab/git && \
     jupyter serverextension enable --py jupyterlab_git
@@ -104,6 +104,21 @@ RUN python3 -m pip install "pipx>=0.15.0.0" && \
     pipx install ${RENKU_PIP_SPEC} --pip-args="--pre" && \
     pipx inject renku sentry-sdk && \
     pipx ensurepath
+
+# configure powerline
+COPY powerline.bashrc /tmp/powerline.bashrc
+COPY powerline.config /tmp/powerline.config
+
+RUN cat /tmp/powerline.bashrc >> ~/.bashrc && \
+    pip install powerline-shell && \
+    mkdir -p ~/.config/powerline-shell/ && \
+    cat /tmp/powerline.config >> ~/.config/powerline-shell/config.json
+
+# Add user `rstudio` to sudoers (passwordless)
+USER root
+RUN echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+    rm -rf /wheels
+USER $NB_USER
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT [ "/tini", "--", "/entrypoint.sh" ]


### PR DESCRIPTION
* pinning rsession-proxy for R images to make sure the terminal works
* adding back powerline to R images

This PR also intends to fix the ability for R users to install packages, but at the current state it does not do this.