### PR TITLE
Add nbresuse for resource display in notebooks

### DIFF
--- a/docker/py3.7/Dockerfile
+++ b/docker/py3.7/Dockerfile
@@ -55,6 +55,7 @@ RUN python3 -m pip install -U pip && \
     jupyter labextension update @jupyterlab/hub-extension --no-build && \
     jupyter labextension install @jupyterlab/git --no-build && \
     jupyter labextension install @jupyterlab/toc --no-build && \
+    jupyter labextension install jupyterlab-topbar-extension jupyterlab-system-monitor && \
     jupyter labextension list && \
     pip install jupyterlab-git && \
     jupyter serverextension enable --py jupyterlab_git && \

--- a/docker/py3.7/requirements.txt
+++ b/docker/py3.7/requirements.txt
@@ -2,3 +2,4 @@ papermill<1.2.0
 requests>=2.20.0
 jupyterlab==1.2.6
 jupyterhub==1.1.0
+nbresuse==0.3.3


### PR DESCRIPTION
closes #33 

Adds https://github.com/jtpio/jupyterlab-system-monitor which uses https://github.com/yuvipanda/nbresuse.

I think we should add some configs in `~/.jupyter/jupyter_notebook_config.py` like the example before merging:
```
c = get_config()

# memory
c.NotebookApp.ResourceUseDisplay.mem_limit = <size_in_GB> *1024*1024*1024

# cpu
c.NotebookApp.ResourceUseDisplay.track_cpu_percent = True
c.NotebookApp.ResourceUseDisplay.cpu_limit = <number_of_cpus>
```
