### PR TITLE
fix: ensure local/bin is in PATH

### DIFF
--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -60,9 +60,10 @@ RUN conda install gxx_linux-64 && \
 # install renku-python
 ENV RENKU_DISABLE_VERSION_CHECK 1
 
+ENV PATH=$HOME/.local/bin:$PATH
+
 RUN pipx install --pip-args="--no-cache" renku && \
-    pipx inject --pip-args="--no-cache" renku sentry-sdk && \
-    echo "export PATH=\"$PATH:/home/${NB_USER}/.local/bin\"" >> /home/${NB_USER}/.bashrc
+    pipx inject --pip-args="--no-cache" renku sentry-sdk
 
 # configure git
 COPY git-config.bashrc /home/$NB_USER/

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -18,8 +18,9 @@ ENV HOME /home/${NB_USER}
 ENV SHELL bash
 ENV CONDA_PATH /opt/conda
 
-# prepend conda to PATH
-ENV PATH ${CONDA_PATH}/bin:$PATH
+# prepend conda and local/bin to PATH
+ENV PATH ~/.local/bin:${CONDA_PATH}/bin:$PATH
+
 # And set PATH for R! It doesn't read from the environment...
 RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron && \
     echo "PATH=${PATH}" >> /etc/profile.d/set_path.sh


### PR DESCRIPTION
Fixes the problem where the jupyterlab git extension environment did not have `~/.local/bin` in the `PATH`