### PR TITLE
feat: add vscode to base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,26 +62,23 @@ pull:
 		docker pull $(DOCKER_PREFIX)$$ext:$(DOCKER_LABEL) ; \
 	done
 
-r: py3.7
+r: py
 	docker build docker/r \
-		--build-arg RENKU_PIP_SPEC=$(RENKU_PIP_SPEC) \
 		--build-arg RENKU_BASE=renku/renkulab-py3.7:$(GIT_MASTER_HEAD_SHA)$(RENKU_TAG) \
 		--build-arg RVERSION=$(RVERSION) \
 		-t $(DOCKER_PREFIX)-r:$(DOCKER_LABEL)$(RENKU_TAG)$(R_TAG) && \
 	docker tag $(DOCKER_PREFIX)-r:$(DOCKER_LABEL)$(RENKU_TAG)$(R_TAG) $(DOCKER_PREFIX)-r:$(GIT_MASTER_HEAD_SHA)$(RENKU_TAG)$(R_TAG)
 
-bioc: py3.7
+bioc: py
 	docker build docker/bioc \
-		--build-arg RENKU_PIP_SPEC=$(RENKU_PIP_SPEC) \
 		--build-arg RENKU_BASE=renku/renkulab-py3.7:$(GIT_MASTER_HEAD_SHA)$(RENKU_TAG) \
 		--build-arg RELEASE=$(BIOC_VERSION) \
 		-t $(DOCKER_PREFIX)-bioc:$(DOCKER_LABEL)$(RENKU_TAG)$(BIOC_TAG) && \
 	docker tag $(DOCKER_PREFIX)-bioc:$(DOCKER_LABEL)$(RENKU_TAG)$(BIOC_TAG) $(DOCKER_PREFIX)-bioc:$(GIT_MASTER_HEAD_SHA)$(RENKU_TAG)$(BIOC_TAG)
 
 
-py3.7:
+py:
 	cd docker/$@ && \
 	docker build \
-		--build-arg RENKU_PIP_SPEC=${RENKU_PIP_SPEC} \
 		-t $(DOCKER_PREFIX)-$@:$(DOCKER_LABEL)$(RENKU_TAG) . && \
 	docker tag $(DOCKER_PREFIX)-$@:$(DOCKER_LABEL)$(RENKU_TAG) $(DOCKER_PREFIX)-$@:$(GIT_MASTER_HEAD_SHA)$(RENKU_TAG)

--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -29,10 +29,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     python-dev \
     unzip \
     vim && \
-    wget https://github.com/cdr/code-server/releases/download/v3.6.2/code-server_3.6.2_amd64.deb && \
-    dpkg -i ./code-server*.deb && \
-    rm code-server_3.6.2_amd64.deb && \
-    apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
 
@@ -49,12 +45,9 @@ RUN python3 -m pip install --no-cache -U pip && \
     python3 -m pip install --no-cache -r /tmp/requirements.txt && \
     jupyter labextension install --no-build @jupyterlab/toc && \
     jupyter labextension install --no-build jupyterlab-topbar-extension jupyterlab-system-monitor && \
-    jupyter serverextension enable --py jupyter_server_proxy && \
-    jupyter labextension install --no-build @jupyterlab/server-proxy && \
     jupyter lab build && \
     jupyter labextension list && \
     npm cache clean --force && \
-    code-server --install-extension ms-python.python && \
     rm -rf /home/${NB_USER}/.cache
 
 # fix https://github.com/SwissDataScienceCenter/renku-jupyter/issues/14

--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -29,6 +29,9 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     python-dev \
     unzip \
     vim && \
+    wget https://github.com/cdr/code-server/releases/download/v3.6.2/code-server_3.6.2_amd64.deb && \
+    dpkg -i ./code-server*.deb && \
+    rm code-server_3.6.2_amd64.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
@@ -46,9 +49,12 @@ RUN python3 -m pip install --no-cache -U pip && \
     python3 -m pip install --no-cache -r /tmp/requirements.txt && \
     jupyter labextension install --no-build @jupyterlab/toc && \
     jupyter labextension install --no-build jupyterlab-topbar-extension jupyterlab-system-monitor && \
+    jupyter serverextension enable --py jupyter_server_proxy && \
+    jupyter labextension install --no-build @jupyterlab/server-proxy && \
     jupyter lab build && \
     jupyter labextension list && \
     npm cache clean --force && \
+    code-server --install-extension ms-python.python && \
     rm -rf /home/${NB_USER}/.cache
 
 # fix https://github.com/SwissDataScienceCenter/renku-jupyter/issues/14

--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     python-dev \
     unzip \
     vim && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /usr/lib/x86_64-linux-musl/libc.so /lib/libc.musl-x86_64.so.1
 

--- a/docker/py/requirements.txt
+++ b/docker/py/requirements.txt
@@ -1,8 +1,9 @@
-git+https://github.com/betatim/vscode-binder
 jupyterhub==1.1.0
 jupyterlab-git==0.20.0
+jupyterlab_server~=1.0.0
 jupyter-server-proxy==1.5.0
 nbresuse==0.3.6
+nbclient<0.5.1
 papermill==2.1.3
 pipx>=0.15.0.0
 powerline-shell==0.7.0

--- a/docker/py/requirements.txt
+++ b/docker/py/requirements.txt
@@ -1,7 +1,9 @@
-papermill==2.1.3
-requests>=2.20.0
+git+https://github.com/betatim/vscode-binder
 jupyterhub==1.1.0
-nbresuse==0.3.6
 jupyterlab-git==0.20.0
+jupyter-server-proxy==1.5.0
+nbresuse==0.3.6
+papermill==2.1.3
 pipx>=0.15.0.0
 powerline-shell==0.7.0
+requests>=2.20.0

--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+VSCODE_VERSION=${VSCODE_VERSION:="3.6.2"}
+
+# code-server installation
+wget https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_3.6.2_amd64.deb
+dpkg -i ./code-server*.deb
+rm code-server_3.6.2_amd64.deb
+apt-get clean
+code-server --install-extension ms-python.python
+chown -R 1000:1000 /home/${NB_USER}/.local/share
+
+# Jupyter support
+pip install git+https://github.com/betatim/vscode-binder
+jupyter serverextension enable --py jupyter_server_proxy && \
+jupyter labextension install --no-build @jupyterlab/server-proxy


### PR DESCRIPTION
Adds VSCode using [code-server](https://github.com/cdr/code-server) and [jupyter-vscode-proxy](https://github.com/betatim/vscode-binder).

For testing, you can ~~use this image: `renku/renkulab-py:3.7-c43683d`~~ add these lines to your `Dockerfile`:

```
USER root
RUN curl -s https://raw.githubusercontent.com/SwissDataScienceCenter/renkulab-docker/c50af197ccd7b727b9baa0aebf60602c669ab546/scripts/install-vscode.sh | bash
USER ${NB_USER}
```

closes #83