### PR TITLE
chore: do the jupyter build at the end of vscode script

### DIFF
--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-VSCODE_VERSION=${VSCODE_VERSION:="3.6.2"}
+VSCODE_VERSION=${VSCODE_VERSION:="3.8.1"}
 
 # code-server installation
-wget https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_3.6.2_amd64.deb
+wget https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 dpkg -i ./code-server*.deb
 rm code-server_3.6.2_amd64.deb
 apt-get clean

--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -13,4 +13,4 @@ chown -R 1000:1000 /home/${NB_USER}/.local/share
 # Jupyter support
 pip install git+https://github.com/betatim/vscode-binder
 jupyter serverextension enable --py jupyter_server_proxy && \
-jupyter labextension install --no-build @jupyterlab/server-proxy
+jupyter labextension install @jupyterlab/server-proxy


### PR DESCRIPTION
avoid jupyter rebuilds on session launch and bump vscode version

you can test it here: https://dev.renku.ch/projects/rokroskar/test-vscode/environments/new (just select `/lab` before launching)