### PR TITLE
chore: fix up python extension installation for vscode

### DIFF
--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -3,10 +3,14 @@
 VSCODE_VERSION=${VSCODE_VERSION:="3.8.1"}
 
 # code-server installation
-wget https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
-dpkg -i ./code-server*.deb
-rm code-server_${VSCODE_VERSION}_amd64.deb
-apt-get clean
+# wget https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
+# dpkg -i ./code-server*.deb
+# rm code-server_${VSCODE_VERSION}_amd64.deb
+# apt-get clean
+curl -fL https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server-${VSCODE_VERSION}-linux-amd64.tar.gz \
+  | tar -C ~/.local/lib -xz 
+mv ~/.local/lib/code-server-${VSCODE_VERSION}-linux-amd64 ~/.local/lib/code-server-${VSCODE_VERSION}
+ln -s ~/.local/lib/code-server-${VSCODE_VERSION}/bin/code-server ~/.local/bin/code-server
 
 # Fix broken python plugin # https://github.com/cdr/code-server/issues/2341
 mkdir -p /home/{$NB_USER}/.local/share/code-server/

--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -13,9 +13,9 @@ mv ~/.local/lib/code-server-${VSCODE_VERSION}-linux-amd64 ~/.local/lib/code-serv
 ln -s ~/.local/lib/code-server-${VSCODE_VERSION}/bin/code-server ~/.local/bin/code-server
 
 # Fix broken python plugin # https://github.com/cdr/code-server/issues/2341
-mkdir -p /home/{$NB_USER}/.local/share/code-server/
-mkdir -p /home/{$NB_USER}/.local/share/code-server/User
-echo "{\"extensions.autoCheckUpdates\": false, \"extensions.autoUpdate\": false}" > /home/{$NB_USER}/.local/share/code-server/User/settings.json
+mkdir -p /home/${NB_USER}/.local/share/code-server/
+mkdir -p /home/${NB_USER}/.local/share/code-server/User
+echo "{\"extensions.autoCheckUpdates\": false, \"extensions.autoUpdate\": false}" > /home/${NB_USER}/.local/share/code-server/User/settings.json
 wget https://github.com/microsoft/vscode-python/releases/download/2020.10.332292344/ms-python-release.vsix
 code-server --install-extension ./ms-python-release.vsix || true
 rm -rf ./ms-python-release.vsix

--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -7,6 +7,7 @@ VSCODE_VERSION=${VSCODE_VERSION:="3.8.1"}
 # dpkg -i ./code-server*.deb
 # rm code-server_${VSCODE_VERSION}_amd64.deb
 # apt-get clean
+mkdir -p ~/.local/lib
 curl -fL https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server-${VSCODE_VERSION}-linux-amd64.tar.gz \
   | tar -C ~/.local/lib -xz 
 mv ~/.local/lib/code-server-${VSCODE_VERSION}-linux-amd64 ~/.local/lib/code-server-${VSCODE_VERSION}

--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -7,10 +7,17 @@ wget https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/cod
 dpkg -i ./code-server*.deb
 rm code-server_${VSCODE_VERSION}_amd64.deb
 apt-get clean
-code-server --install-extension ms-python.python
+
+# Fix broken python plugin # https://github.com/cdr/code-server/issues/2341
+mkdir -p /home/{$NB_USER}/.local/share/code-server/
+mkdir -p /home/{$NB_USER}/.local/share/code-server/User
+echo "{\"extensions.autoCheckUpdates\": false, \"extensions.autoUpdate\": false}" > /home/{$NB_USER}/.local/share/code-server/User/settings.json
+wget https://github.com/microsoft/vscode-python/releases/download/2020.10.332292344/ms-python-release.vsix
+code-server --install-extension ./ms-python-release.vsix || true
+rm -rf ./ms-python-release.vsix
 chown -R 1000:1000 /home/${NB_USER}/.local/share
 
 # Jupyter support
 pip install git+https://github.com/betatim/vscode-binder
-jupyter serverextension enable --py jupyter_server_proxy && \
+jupyter serverextension enable --py jupyter_server_proxy
 jupyter labextension install @jupyterlab/server-proxy

--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -5,7 +5,7 @@ VSCODE_VERSION=${VSCODE_VERSION:="3.8.1"}
 # code-server installation
 wget https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
 dpkg -i ./code-server*.deb
-rm code-server_3.6.2_amd64.deb
+rm code-server_${VSCODE_VERSION}_amd64.deb
 apt-get clean
 code-server --install-extension ms-python.python
 chown -R 1000:1000 /home/${NB_USER}/.local/share

--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -3,10 +3,6 @@
 VSCODE_VERSION=${VSCODE_VERSION:="3.8.1"}
 
 # code-server installation
-# wget https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server_${VSCODE_VERSION}_amd64.deb
-# dpkg -i ./code-server*.deb
-# rm code-server_${VSCODE_VERSION}_amd64.deb
-# apt-get clean
 mkdir -p ~/.local/lib
 curl -fL https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server-${VSCODE_VERSION}-linux-amd64.tar.gz \
   | tar -C ~/.local/lib -xz 


### PR DESCRIPTION
There are problems with newer versions of the Python extension - this PR modifies the python extension installation in vscode to manually install a version that works. 