### PR TITLE
chore: use bash instead of executable scripts

### DIFF
--- a/docker/py/entrypoint.sh
+++ b/docker/py/entrypoint.sh
@@ -37,12 +37,12 @@ find /tmp/renku-env -not -path '*.git*' -type f -print0 | xargs --null -I{} sh -
 
 # run the post-init script in the root directory (i.e. coming from the image)
 if [ -f "/post-init.sh" ]; then
-    /post-init.sh
+    bash /post-init.sh
 fi
 
 # run the post-init script in the project directory
 if [ -f "./post-init.sh" ]; then
-    ./post-init.sh
+    bash ./post-init.sh
 fi
 
 # run the command


### PR DESCRIPTION
If a template adds a `post-init.sh` file, it cannot preserve the executable bit at the moment which causes the entrypoint to fail in running the extra script. This fixes the problem by running the script through `bash`. 

Thanks @ltalirz for pointing this out!