### PR TITLE
chore: update julia version to 1.6.1

### DIFF
--- a/docker/julia/Dockerfile
+++ b/docker/julia/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=renku/renkulab-py:3.7-0.7.3
+ARG BASE_IMAGE=renku/renkulab-py:latest
 FROM $BASE_IMAGE as base
 
 LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
@@ -10,7 +10,7 @@ USER root
 ENV JULIA_DEPOT_PATH=/opt/julia
 ENV JULIA_PKGDIR=/opt/julia
 # If this changes, you also need to change the checksum below
-ENV JULIA_VERSION=1.5.3
+ENV JULIA_VERSION=1.6.1
 
 RUN mkdir /opt/julia-${JULIA_VERSION} && \
     cd /tmp && \

--- a/docker/julia/Dockerfile
+++ b/docker/julia/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=renku/renkulab-py:latest
+ARG BASE_IMAGE=renku/renkulab-py:3.8-0.7.5
 FROM $BASE_IMAGE as base
 
 LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
@@ -15,7 +15,7 @@ ENV JULIA_VERSION=1.6.1
 RUN mkdir /opt/julia-${JULIA_VERSION} && \
     cd /tmp && \
     wget -q https://julialang-s3.julialang.org/bin/linux/x64/`echo ${JULIA_VERSION} | cut -d. -f 1,2`/julia-${JULIA_VERSION}-linux-x86_64.tar.gz && \
-    echo "f190c938dd6fed97021953240523c9db448ec0a6760b574afd4e9924ab5615f1 *julia-${JULIA_VERSION}-linux-x86_64.tar.gz" | sha256sum -c - && \
+    echo "7c888adec3ea42afbfed2ce756ce1164a570d50fa7506c3f2e1e2cbc49d52506 *julia-${JULIA_VERSION}-linux-x86_64.tar.gz" | sha256sum -c - && \
     tar xzf julia-${JULIA_VERSION}-linux-x86_64.tar.gz -C /opt/julia-${JULIA_VERSION} --strip-components=1 && \
     rm /tmp/julia-${JULIA_VERSION}-linux-x86_64.tar.gz
 RUN ln -fs /opt/julia-*/bin/julia /usr/local/bin/julia

--- a/docker/vnc/Dockerfile
+++ b/docker/vnc/Dockerfile
@@ -46,7 +46,7 @@ COPY --chown=root:root vnc_renku.html /opt/noVNC-${novnc_version}
 
 ENV tigervnc_version=1.9.0
 
-RUN curl -sSfL https://github.com/accetto/tigervnc/releases/download/v${tigervnc_version}-mirror/tigervnc-${tigervnc_version}.x86_64.tar.gz | tar -zxf - -C /usr/local --strip=2
+RUN curl -sSfL https://sourceforge.net/projects/tigervnc/files/stable/${tigervnc_version}/tigervnc-${tigervnc_version}.x86_64.tar.gz/download | tar -zxf - -C /usr/local --strip=2
 
 #################################################################
 # Add desktop icons

--- a/docker/vnc/Dockerfile
+++ b/docker/vnc/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=renku/renkulab-py:latest
+ARG BASE_IMAGE=renku/renkulab-py:3.8-0.7.5
 FROM ${BASE_IMAGE}
 
 LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
@@ -46,7 +46,7 @@ COPY --chown=root:root vnc_renku.html /opt/noVNC-${novnc_version}
 
 ENV tigervnc_version=1.9.0
 
-RUN curl -sSfL https://bintray.com/tigervnc/stable/download_file?file_path=tigervnc-${tigervnc_version}.x86_64.tar.gz | tar -zxf - -C /usr/local --strip=2
+RUN curl -sSfL https://github.com/accetto/tigervnc/releases/download/v${tigervnc_version}-mirror/tigervnc-${tigervnc_version}.x86_64.tar.gz | tar -zxf - -C /usr/local --strip=2
 
 #################################################################
 # Add desktop icons


### PR DESCRIPTION
The latest version of the julia Dockerfiles is 1.5.3 but 1.6.1 is available now.