### PR TITLE
chore: update tigervnc source

### DIFF
--- a/docker/vnc/Dockerfile
+++ b/docker/vnc/Dockerfile
@@ -46,7 +46,7 @@ COPY --chown=root:root vnc_renku.html /opt/noVNC-${novnc_version}
 
 ENV tigervnc_version=1.9.0
 
-RUN curl -sSfL https://github.com/accetto/tigervnc/releases/download/v${tigervnc_version}-mirror/tigervnc-${tigervnc_version}.x86_64.tar.gz | tar -zxf - -C /usr/local --strip=2
+RUN curl -sSfL https://sourceforge.net/projects/tigervnc/files/stable/${tigervnc_version}/tigervnc-${tigervnc_version}.x86_64.tar.gz/download | tar -zxf - -C /usr/local --strip=2
 
 #################################################################
 # Add desktop icons

--- a/docker/vnc/Dockerfile
+++ b/docker/vnc/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=renku/renkulab-py:latest
+ARG BASE_IMAGE=renku/renkulab-py:3.8-0.7.5
 FROM ${BASE_IMAGE}
 
 LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
@@ -46,7 +46,7 @@ COPY --chown=root:root vnc_renku.html /opt/noVNC-${novnc_version}
 
 ENV tigervnc_version=1.9.0
 
-RUN curl -sSfL https://bintray.com/tigervnc/stable/download_file?file_path=tigervnc-${tigervnc_version}.x86_64.tar.gz | tar -zxf - -C /usr/local --strip=2
+RUN curl -sSfL https://github.com/accetto/tigervnc/releases/download/v${tigervnc_version}-mirror/tigervnc-${tigervnc_version}.x86_64.tar.gz | tar -zxf - -C /usr/local --strip=2
 
 #################################################################
 # Add desktop icons


### PR DESCRIPTION
- The hosting service at bintray, which hosted tigervnc binaries, has been 'sunset' as of May 1 2021.
- A github release repo was set up by a community user to host those binaries.
- ~~The owner has not mentioned plans to switch hosting (e.g. sourceforge)~~ they have moved to sourceforge!
- The package that comes on apt-get is not the same one as the ones provided directly, so I'm opting for this (temporary, but stable) solution.

