### PR TITLE
chore: upgrades rstudio to 1.3.959

### DIFF
--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -1,5 +1,5 @@
 # define build arguments
-ARG RENKU_BASE=renku/renkulab-py:3.8-0.7.6
+ARG RENKU_BASE=renku/renkulab-py:latest
 ARG BASE_IMAGE=rocker/verse:4.0.4
 
 # define base images

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -1,5 +1,5 @@
 # define build arguments
-ARG RENKU_BASE=renku/renkulab-py:latest
+ARG RENKU_BASE=renku/renkulab-py:3.8-0.7.6
 ARG BASE_IMAGE=rocker/verse:4.0.4
 
 # define base images
@@ -30,7 +30,7 @@ RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron && \
 ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
 
 # pin the version of RStudio
-ENV RSTUDIO_VERSION 1.2.5042
+ENV RSTUDIO_VERSION 1.3.959
 RUN /rocker_scripts/install_rstudio.sh
 
 # Add Tini


### PR DESCRIPTION
Upgrades RStudio to the newest working version, according to https://github.com/rocker-org/rocker-versioned2/issues/88#issuecomment-720013981

RStudio 1.4.X does not work yet, but #154 will be closed for now

closes #154 