### PR TITLE
chore: include newer R versions

### DIFF
--- a/.github/workflows/build_and_push_to_docker.yml
+++ b/.github/workflows/build_and_push_to_docker.yml
@@ -164,6 +164,7 @@ jobs:
           - devel
           - RELEASE_3_11
           - RELEASE_3_12
+          - RELEASE_3_13
     steps:
     - name: Docker Login
       uses: Azure/docker-login@v1

--- a/.github/workflows/build_and_push_to_docker.yml
+++ b/.github/workflows/build_and_push_to_docker.yml
@@ -118,7 +118,8 @@ jobs:
           - 4.0.3
           - 4.0.4
           - 4.0.5
-          - 4.1.0
+          # TODO: enable once compatibility issues are fixed  - see #154 and #160
+          # - 4.1.0
     steps:
     - name: Docker Login
       uses: Azure/docker-login@v1
@@ -164,7 +165,8 @@ jobs:
           - devel
           - RELEASE_3_11
           - RELEASE_3_12
-          - RELEASE_3_13
+          # TODO: enable once compatibility issues are fixed - see #154 and #160
+          # - RELEASE_3_13
     steps:
     - name: Docker Login
       uses: Azure/docker-login@v1

--- a/.github/workflows/build_and_push_to_docker.yml
+++ b/.github/workflows/build_and_push_to_docker.yml
@@ -144,7 +144,7 @@ jobs:
         docker push $DOCKER_NAME-r:$DOCKER_TAG
 
         # on master push latest image
-        if [ "$REF" == "refs/heads/master" ] && [ "$RVERSION" == "4.0.4" ]
+        if [ "$REF" == "refs/heads/master" ] && [ "$RVERSION" == "4.0.5" ]
         then
           docker tag $DOCKER_NAME-r:$DOCKER_TAG $DOCKER_NAME-r:latest
           docker push $DOCKER_NAME-r:latest

--- a/.github/workflows/build_and_push_to_docker.yml
+++ b/.github/workflows/build_and_push_to_docker.yml
@@ -117,6 +117,8 @@ jobs:
         RVERSIONS:
           - 4.0.3
           - 4.0.4
+          - 4.0.5
+          - 4.1.0
     steps:
     - name: Docker Login
       uses: Azure/docker-login@v1

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -1,6 +1,6 @@
 # define build arguments
 ARG RENKU_BASE=renku/renkulab-py:latest
-ARG BASE_IMAGE=rocker/verse:4.0.4
+ARG BASE_IMAGE=rocker/verse:4.0.5
 
 # define base images
 FROM $RENKU_BASE as renku_base


### PR DESCRIPTION
Adds R `4.0.5` ~~and `4.1.0` and bioconductor `3.13`~~ 

Bumping to R `4.1.0` and bioc `3.13` depends on #154 and #160. 