### PR TITLE
chore: upgrade vscode and python extension

### DIFF
--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VSCODE_VERSION=${VSCODE_VERSION:="3.8.1"}
+VSCODE_VERSION=${VSCODE_VERSION:="3.10.2"}
 
 # code-server installation
 mkdir -p ~/.local/lib
@@ -9,14 +9,9 @@ curl -fL https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}
 mv ~/.local/lib/code-server-${VSCODE_VERSION}-linux-amd64 ~/.local/lib/code-server-${VSCODE_VERSION}
 ln -s ~/.local/lib/code-server-${VSCODE_VERSION}/bin/code-server ~/.local/bin/code-server
 
-# Fix broken python plugin # https://github.com/cdr/code-server/issues/2341
-mkdir -p /home/${NB_USER}/.local/share/code-server/
-mkdir -p /home/${NB_USER}/.local/share/code-server/User
-echo "{\"extensions.autoCheckUpdates\": false, \"extensions.autoUpdate\": false}" > /home/${NB_USER}/.local/share/code-server/User/settings.json
-wget https://github.com/microsoft/vscode-python/releases/download/2020.10.332292344/ms-python-release.vsix
-code-server --install-extension ./ms-python-release.vsix || true
-rm -rf ./ms-python-release.vsix
-chown -R 1000:1000 /home/${NB_USER}/.local/share
+# python extension
+code-server --install-extension ms-python.python
+pip install pylint
 
 # Jupyter support
 pip install git+https://github.com/betatim/vscode-binder


### PR DESCRIPTION
1. Update vscode version to the latest - 3.10.2
2. The issue with python extension is resolved in the latest version
3. Add pylint for python