### PR TITLE
update python version 3.8 to 3.9

### DIFF
--- a/.github/workflows/build_and_push_to_docker.yml
+++ b/.github/workflows/build_and_push_to_docker.yml
@@ -24,13 +24,13 @@ jobs:
           export LABEL=$(echo ${{ github.sha }} | cut -c 1-7)
         fi
 
-        docker build docker/py --tag $DOCKER_NAME-py:3.8-$LABEL
-        docker push $DOCKER_NAME-py:3.8-$LABEL
+        docker build docker/py --tag $DOCKER_NAME-py:3.9-$LABEL
+        docker push $DOCKER_NAME-py:3.9-$LABEL
 
         # on master push latest image
         if [ "$REF" == "refs/heads/master" ]
         then
-          docker tag $DOCKER_NAME-py:3.8-$LABEL $DOCKER_NAME-py:latest
+          docker tag $DOCKER_NAME-py:3.9-$LABEL $DOCKER_NAME-py:latest
           docker push $DOCKER_NAME-py:latest
         fi
       env:
@@ -64,7 +64,7 @@ jobs:
         fi
 
         docker build docker/$EXTENSION \
-          --build-arg BASE_IMAGE="$DOCKER_NAME-py:3.8-$LABEL" \
+          --build-arg BASE_IMAGE="$DOCKER_NAME-py:3.9-$LABEL" \
           --tag $DOCKER_NAME-$EXTENSION:$LABEL
         docker push $DOCKER_NAME-$EXTENSION:$LABEL
       env:
@@ -99,7 +99,7 @@ jobs:
 
         export DOCKER_TAG="$JULIAVERSION-$LABEL"
         docker build docker/julia \
-          --build-arg BASE_IMAGE="$DOCKER_NAME-py:3.8-$LABEL" \
+          --build-arg BASE_IMAGE="$DOCKER_NAME-py:3.9-$LABEL" \
           --tag $DOCKER_NAME-julia:$DOCKER_TAG
         docker push $DOCKER_NAME-julia:$DOCKER_TAG
       env:
@@ -137,7 +137,7 @@ jobs:
 
         export DOCKER_TAG="$RVERSION-$LABEL"
         docker build docker/r \
-          --build-arg RENKU_BASE="$DOCKER_NAME-py:3.8-$LABEL" \
+          --build-arg RENKU_BASE="$DOCKER_NAME-py:3.9-$LABEL" \
           --build-arg BASE_IMAGE="rocker/verse:${RVERSION}" \
           --tag $DOCKER_NAME-r:$DOCKER_TAG
         docker push $DOCKER_NAME-r:$DOCKER_TAG
@@ -184,7 +184,7 @@ jobs:
 
         export DOCKER_TAG="$RELEASE-$LABEL"
         docker build docker/r \
-          --build-arg RENKU_BASE="$DOCKER_NAME-py:3.8-$LABEL" \
+          --build-arg RENKU_BASE="$DOCKER_NAME-py:3.9-$LABEL" \
           --build-arg BASE_IMAGE=bioconductor/bioconductor_docker:${RELEASE} \
           --tag $DOCKER_NAME-bioc:$DOCKER_TAG
         docker push $DOCKER_NAME-bioc:$DOCKER_TAG

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ pipx install --force renku==<version>
 
 | Release | Release Date | Python | R            | Julia | Bioconductor | Cuda TF |
 |---------|--------------|--------|--------------|-------|--------------|---------|
-| [0.8.0](https://github.com/SwissDataScienceCenter/renkulab-docker/releases/tag/0.8.0) | 9 July 2021 | [3.8](https://hub.docker.com/r/renku/renkulab-py/tags?page=1&ordering=last_updated&name=0.8.0)    | [4.0.3](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.3-0.8.0), [4.0.4](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.4-0.8.0), [4.0.5](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.5-0.8.0) | [1.6.1](https://hub.docker.com/r/renku/renkulab-julia/tags?page=1&ordering=last_updated&name=1.6.1-0.8.0) | [3.11](https://hub.docker.com/r/renku/renkulab-bioc/tags?page=1&ordering=last_updated&name=RELEASE_3_11-0.8.0), [3.12](https://hub.docker.com/r/renku/renkulab-bioc/tags?page=1&ordering=last_updated&name=RELEASE_3_12-0.8.0)   |  [CUDA 11.0.3, TF 2.5.0](https://hub.docker.com/r/renku/renkulab-cuda-tf/tags?page=1&ordering=last_updated&name=0.8.0)                 |
+| [0.8.0](https://github.com/SwissDataScienceCenter/renkulab-docker/releases/tag/0.8.0) | 9 July 2021 | [3.9](https://hub.docker.com/r/renku/renkulab-py/tags?page=1&ordering=last_updated&name=0.8.0)    | [4.0.3](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.3-0.8.0), [4.0.4](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.4-0.8.0), [4.0.5](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.5-0.8.0) | [1.6.1](https://hub.docker.com/r/renku/renkulab-julia/tags?page=1&ordering=last_updated&name=1.6.1-0.8.0) | [3.11](https://hub.docker.com/r/renku/renkulab-bioc/tags?page=1&ordering=last_updated&name=RELEASE_3_11-0.8.0), [3.12](https://hub.docker.com/r/renku/renkulab-bioc/tags?page=1&ordering=last_updated&name=RELEASE_3_12-0.8.0)   |  [CUDA 11.0.3, TF 2.5.0](https://hub.docker.com/r/renku/renkulab-cuda-tf/tags?page=1&ordering=last_updated&name=0.8.0)                 |
 | [0.7.7](https://github.com/SwissDataScienceCenter/renkulab-docker/releases/tag/0.7.7) | 10 June 2021 | [3.8](https://hub.docker.com/r/renku/renkulab-py/tags?page=1&ordering=last_updated&name=0.7.7)    | [4.0.3](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.3-0.7.7), [4.0.4](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.4-0.7.7), [4.0.5](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.5-0.7.7) | [1.6.1](https://hub.docker.com/r/renku/renkulab-julia/tags?page=1&ordering=last_updated&name=1.6.1-0.7.7) | [3.11](https://hub.docker.com/r/renku/renkulab-bioc/tags?page=1&ordering=last_updated&name=RELEASE_3_11-0.7.7), [3.12](https://hub.docker.com/r/renku/renkulab-bioc/tags?page=1&ordering=last_updated&name=RELEASE_3_12-0.7.7)   |  [CUDA 11.0.3, TF 2.4](https://hub.docker.com/r/renku/renkulab-cuda-tf/tags?page=1&ordering=last_updated&name=0.7.7)                 |
 | [0.7.6](https://github.com/SwissDataScienceCenter/renkulab-docker/releases/tag/0.7.6) | 10 May 2021 | [3.8](https://hub.docker.com/r/renku/renkulab-py/tags?page=1&ordering=last_updated&name=0.7.6)    | [4.0.3](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.3-0.7.6), [4.0.4](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.4-0.7.6) | [1.6.1](https://hub.docker.com/r/renku/renkulab-julia/tags?page=1&ordering=last_updated&name=1.6.1-0.7.6) | [3.11](https://hub.docker.com/r/renku/renkulab-bioc/tags?page=1&ordering=last_updated&name=RELEASE_3_11-0.7.6), [3.12](https://hub.docker.com/r/renku/renkulab-bioc/tags?page=1&ordering=last_updated&name=RELEASE_3_12-0.7.6)   |  [CUDA 11.0.3, TF 2.4](https://hub.docker.com/r/renku/renkulab-cuda-tf/tags?page=1&ordering=last_updated&name=0.7.6)                 |
 | [0.7.5](https://github.com/SwissDataScienceCenter/renkulab-docker/releases/tag/0.7.5) | 6 Apr 2021  | [3.8](https://hub.docker.com/r/renku/renkulab-py/tags?page=1&ordering=last_updated&name=0.7.5)    | [4.0.3](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.3-0.7.5), [4.0.4](https://hub.docker.com/r/renku/renkulab-r/tags?page=1&ordering=last_updated&name=4.0.4-0.7.5) | [1.5.3](https://hub.docker.com/r/renku/renkulab-julia/tags?page=1&ordering=last_updated&name=1.5.3-0.7.5) | [3.11](https://hub.docker.com/r/renku/renkulab-bioc/tags?page=1&ordering=last_updated&name=RELEASE_3_11-0.7.5), [3.12](https://hub.docker.com/r/renku/renkulab-bioc/tags?page=1&ordering=last_updated&name=RELEASE_3_12-0.7.5)   | [CUDA 11.0.3, TF 2.4](https://hub.docker.com/r/renku/renkulab-cuda-tf/tags?page=1&ordering=last_updated&name=0.7.5)    |
@@ -111,7 +111,7 @@ dockerhub: https://hub.docker.com/r/renku/renkulab-r/tags
 
 **Available via renku project templates**
 
-Based on the renkulab-py (python 3.8) image with julia installed.
+Based on the renkulab-py (python 3.9) image with julia installed.
 
 dockerhub: https://hub.docker.com/r/renku/renkulab-julia/tags
 
@@ -125,13 +125,13 @@ dockerhub: https://hub.docker.com/r/renku/renkulab-bioc/tags
 
 ### cuda-tf
 
-Based on the renkulab-py (python 3.8) with CUDA 11.0.3 and Tensorflow 2.4 installed.
+Based on the renkulab-py (python 3.9) with CUDA 11.0.3 and Tensorflow 2.4 installed.
 
 dockerhub: https://hub.docker.com/r/renku/renkulab-cuda-tf/tags
 
 ### vnc
 
-Based on the renkulab-py (python 3.8) with a full virtual desktop installed.
+Based on the renkulab-py (python 3.9) with a full virtual desktop installed.
 It uses noVNC 1.1.0 and TigerVNC 1.9.0 with a Renku UI to deliver a Linux desktop.
 
 https://hub.docker.com/r/renku/renkulab-vnc/tags


### PR DESCRIPTION
With JupyterLab 3.0, the default Python version is now 3.9.