### PR TITLE
chore: add gcc to base batch image

### DIFF
--- a/docker/batch/Dockerfile
+++ b/docker/batch/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -y && \
     apt-get install -y curl && \
     curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
     apt-get update -y && \
-    apt-get install -y git git-lfs nodejs && \
+    apt-get install -y gcc git git-lfs nodejs && \
     apt-get purge && \
     apt-get clean && \
     apt autoremove --yes && \


### PR DESCRIPTION
gcc is necessary for most installations