### PR TITLE
Adapt to Amalthea

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ extensions = \
 	r \
 	cuda-9.2 \
 	cuda-10.0-tf \
-	vnc
+	vnc \
+	julia
 
 DOCKER_PREFIX?=renku/renkulab
 DOCKER_LABEL?=latest
@@ -99,3 +100,8 @@ vnc: py
 		-t $(DOCKER_PREFIX)-vnc:$(DOCKER_LABEL)$(RENKU_TAG) && \
 	docker tag $(DOCKER_PREFIX)-vnc:$(DOCKER_LABEL)$(RENKU_TAG) $(DOCKER_PREFIX)-vnc:$(GIT_MASTER_HEAD_SHA)$(RENKU_TAG)
 
+julia: py
+	docker build docker/julia \
+		--build-arg BASE_IMAGE=renku/renkulab-py:$(GIT_MASTER_HEAD_SHA)$(RENKU_TAG) \
+		-t $(DOCKER_PREFIX)-julia:$(DOCKER_LABEL)$(RENKU_TAG) && \
+	docker tag $(DOCKER_PREFIX)-julia:$(DOCKER_LABEL)$(RENKU_TAG) $(DOCKER_PREFIX)-julia:$(GIT_MASTER_HEAD_SHA)$(RENKU_TAG)

--- a/docker/julia/post-init.sh
+++ b/docker/julia/post-init.sh
@@ -2,6 +2,8 @@
 
 # Slip in a replacement for the julia command that sets uses the project
 # environment rather than the root environment
+
+# Pre amalthea
 if [[ -v CI_PROJECT ]];
 then
     ln -sf /work/${CI_PROJECT} ~/work
@@ -9,3 +11,12 @@ then
     printf '/usr/local/bin/julia --project=/work/%s/ "$@"\n' ${CI_PROJECT} >> ~/.local/bin/julia
     chmod u+x ~/.local/bin/julia
 fi
+
+# With amalthea
+if [[ -v PROJECT_NAME && -v NOTEBOOK_DIR ]];
+then
+    echo '#!/usr/bin/env bash' > ~/.local/bin/julia
+    printf '/usr/local/bin/julia --project=%s/ "$@"\n' ${NOTEBOOK_DIR} >> ~/.local/bin/julia
+    chmod u+x ~/.local/bin/julia
+fi
+

--- a/docker/py/entrypoint.sh
+++ b/docker/py/entrypoint.sh
@@ -22,6 +22,18 @@ then
 fi
 
 # install git hooks
+# we need to avoid a race condition where renku could try to install
+# the git hooks before the repo is actually cloned during the execution
+# of the entrypoint of the git sidecar
+if [[ -v GIT_CLONE_REPO && -v NOTEBOOK_DIR ]]
+then
+    while [[ ! -f ./.renku-repo-clone-complete ]]
+    do
+        echo "Waiting for repository to be cloned..."
+        sleep 1
+    done
+    rm ./.renku-repo-clone-complete
+fi
 ~/.local/bin/renku githooks install || true
 
 # run the post-init script in the root directory (i.e. coming from the image)

--- a/docker/py/entrypoint.sh
+++ b/docker/py/entrypoint.sh
@@ -1,36 +1,25 @@
 #!/bin/bash
 
-# Setup git user
-if [ -z "$(git config --global --get user.name)" ]; then
-    git config --global user.name "$GIT_AUTHOR_NAME"
-fi
-if [ -z "$(git config --global --get user.email)" ]; then
-    git config --global user.email "$EMAIL"
-fi
-
-# configure global git credentials
-if [[ -v CI_PROJECT ]];
+if [[ -v GIT_AUTHOR_NAME && -v EMAIL && -v CI_PROJECT ]];
 then
-    # set the global git credentials
-    git config --global credential.helper "store --file=/work/${CI_PROJECT}/.git/credentials"
+    # Setup git user
+    if [ -z "$(git config --global --get user.name)" ]; then
+        git config --global user.name "$GIT_AUTHOR_NAME"
+    fi
+    if [ -z "$(git config --global --get user.email)" ]; then
+        git config --global user.email "$EMAIL"
+    fi
 
-    # link to the home work directory
-    ln -sf /work/${CI_PROJECT} ~/work
+    # configure global git credentials
+    if [[ -v CI_PROJECT ]];
+    then
+        # set the global git credentials
+        git config --global credential.helper "store --file=/work/${CI_PROJECT}/.git/credentials"
+
+        # link to the home work directory
+        ln -sf /work/${CI_PROJECT} ~/work
+    fi
 fi
-
-#
-# copy the environment from renku-env repo
-#
-
-# clone the repo
-proto=$(echo $GITLAB_URL | sed -e's,^\(.*://\).*,\1,g')
-url=$(echo ${GITLAB_URL/$proto/})
-user=$(echo ${CI_REPOSITORY_URL/$proto/} | grep @ | cut -d@ -f1)
-
-git clone --depth 1 ${GITLAB_URL}/${JUPYTERHUB_USER}/renku-env.git /tmp/renku-env || true
-
-# append the contents of all the files to same files in ${HOME}
-find /tmp/renku-env -not -path '*.git*' -type f -print0 | xargs --null -I{} sh -c 'cat {} >> ${HOME}/$(basename "{}")' || true
 
 # install git hooks
 ~/.local/bin/renku githooks install || true

--- a/docker/py/git-config.bashrc
+++ b/docker/py/git-config.bashrc
@@ -1,8 +1,8 @@
 
 # Setup git user
-if [ -z "$(git config --global --get user.name)" ]; then
+if [[ -z "$(git config --global --get user.name)" && -v GIT_AUTHOR_NAME ]]; then
     git config --global user.name "$GIT_AUTHOR_NAME"
 fi
-if [ -z "$(git config --global --get user.email)" ]; then
+if [[ -z "$(git config --global --get user.email)" && -v EMAIL ]]; then
     git config --global user.email "$EMAIL"
 fi

--- a/docker/vnc/post-init.sh
+++ b/docker/vnc/post-init.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
 # Make the default terminal folder the project folder in the vnc
-echo "cd /work/${CI_PROJECT}" >> ~/.bashrc
+if [[ -v CI_PROJECT ]]
+then
+    echo "cd /work/${CI_PROJECT}" >> ~/.bashrc
+fi
+if [[ -v NOTEBOOK_DIR ]]
+then
+    echo "cd ${NOTEBOOK_DIR}" >> ~/.bashrc
+fi
 # Turn the bell off
 echo "bind 'set bell-style none'" >> ~/.bashrc


### PR DESCRIPTION
The goal of this is to maintain as much of the current behaviour with Amalthea-based sessions, while also keeping the images backwards compatible for now.

All the images which I've touched in this PR are on dockerhub as:
- ableuler/renkulab-py:b02a1a2
- ableuler/renkulab-r:b02a1a2-r4.0.4
- ableuler/renkulab-vnc:b02a1a2
- ableuler/renkulab-julia:b02a1a2

Projects on dev using these images are available under 
- https://dev.renku.ch/projects/andi/amalthea-python-image
- https://dev.renku.ch/projects/andi/amalthea-r-image
- https://dev.renku.ch/projects/andi/amalthea-vnc-image
- https://dev.renku.ch/projects/andi/amalthea-julia-image

as well as the respective path on the CI deployment which relies on Amalthea: https://ci-renku-2142.dev.renku.ch/
