### PR TITLE
fix: use virtualenv manually instead of pipx for renku install

### DIFF
--- a/docker/batch/Dockerfile
+++ b/docker/batch/Dockerfile
@@ -17,17 +17,17 @@ RUN apt-get update -y && \
     apt-get purge && \
     apt-get clean && \
     apt autoremove --yes && \
-    rm -rf /var/lib/apt/lists/* 
+    rm -rf /var/lib/apt/lists/*
 
-RUN pip install pipx
+# Install Renku python without pipx in a non-user location
+RUN python3 -m pip install --no-cache pipenv
+RUN virtualenv /share/.renku && \
+    . /share/.renku/bin/activate && \
+    pip install --no-cache renku && \
+    deactivate && \
+    ln -s /share/.renku/bin/renku /share/bin
 
-# override default locations of pipx and app installation
-ENV PIPX_BIN_DIR /share/bin
-ENV PIPX_HOME /share/pipx
 ENV PATH /share/bin:$PATH
-
-# install renku-python
-RUN pipx install --pip-args="--no-cache" renku
 
 # inject entrypoint.sh
 COPY --from=renku_base /entrypoint.sh /entrypoint.sh

--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -59,10 +59,14 @@ RUN conda install gxx_linux-64 && \
 # install renku-python
 ENV RENKU_DISABLE_VERSION_CHECK 1
 
-ENV PATH=$HOME/.local/bin:$PATH
+ENV PATH=$PATH:$HOME/.renku/bin
 
-RUN pipx install --pip-args="--no-cache" renku && \
-    pipx inject --pip-args="--no-cache" renku sentry-sdk
+RUN mkdir -p $HOME/.renku/bin && \
+    virtualenv $HOME/.renku/venv && \
+    source $HOME/.renku/venv/bin/activate && \
+    pip install --no-cache renku sentry-sdk && \
+    deactivate && \
+    ln -s $HOME/.renku/venv/bin/renku $HOME/.renku/bin/renku
 
 # configure git
 COPY git-config.bashrc /home/$NB_USER/

--- a/docker/py/requirements.txt
+++ b/docker/py/requirements.txt
@@ -4,6 +4,7 @@ jupyterlab-git==0.30.1
 jupyterlab-system-monitor~=0.8.0
 jupyterlab~=3.0.0
 papermill~=2.3.0
-pipx>=0.15.0.0
 powerline-shell~=0.7.0
 requests>=2.20.0
+setuptools==57.5.0
+virtualenv>=20.7.2


### PR DESCRIPTION
This PR is a reaction to a breaking change of setuptools which in turn broke our builds as pipx just pullst the latest of setuptools on a regular basis. We have therefore decided to remove pipx as it makes for non-reproducible builds.