### PR TITLE
Fix renku not found error

### DIFF
--- a/docker/py/entrypoint.sh
+++ b/docker/py/entrypoint.sh
@@ -22,7 +22,7 @@ then
 fi
 
 # install git hooks
-~/.local/bin/renku githooks install || true
+renku githooks install || true
 
 # run the post-init script in the root directory (i.e. coming from the image)
 if [ -f "/post-init.sh" ]; then


### PR DESCRIPTION
#187 changed where `renku` is installed.

`renku` is now in either `$HOME/.renku/bin` or `/share/bin` (batch)