### PR TITLE
Fix image build and bump base image version

### DIFF
--- a/docker/batch/Dockerfile
+++ b/docker/batch/Dockerfile
@@ -1,5 +1,5 @@
 # define build arguments
-ARG RENKU_BASE=renku/renkulab-py:3.9-0.10.1
+ARG RENKU_BASE=renku/renkulab-py:latest
 ARG BASE_IMAGE=python:3.9-slim-buster
 ARG RENKU_VERSION=0.16.2
 

--- a/docker/batch/Dockerfile
+++ b/docker/batch/Dockerfile
@@ -1,6 +1,7 @@
 # define build arguments
-ARG RENKU_BASE=renku/renkulab-py:latest
+ARG RENKU_BASE=renku/renkulab-py:3.9-0.10.1
 ARG BASE_IMAGE=python:3.9-slim-buster
+ARG RENKU_VERSION=0.16.2
 
 # define base images
 FROM $RENKU_BASE as renku_base
@@ -20,11 +21,13 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Renku python without pipx in a non-user location
+ARG RENKU_VERSION
 RUN python3 -m pip install --no-cache pipenv
-RUN virtualenv /share/.renku && \
+RUN virtualenv --pip 21.3.1 --setuptools 57.5.0 --wheel 0.36.2  --no-periodic-update /share/.renku && \
     . /share/.renku/bin/activate && \
-    pip install --no-cache renku && \
+    pip install --no-cache renku==$RENKU_VERSION sentry-sdk && \
     deactivate && \
+    mkdir /share/bin && \
     ln -s /share/.renku/bin/renku /share/bin
 
 ENV PATH /share/bin:$PATH

--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -1,5 +1,5 @@
 # Run with the RenkuKubeSpawner via JupyterHub
-ARG BASE_IMAGE=jupyter/base-notebook:lab-3.0.16
+ARG BASE_IMAGE=jupyter/base-notebook:lab-3.2.1
 ARG RENKU_VERSION=0.16.2
 FROM $BASE_IMAGE as base
 

--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -1,5 +1,6 @@
 # Run with the RenkuKubeSpawner via JupyterHub
 ARG BASE_IMAGE=jupyter/base-notebook:lab-3.0.16
+ARG RENKU_VERSION=0.16.2
 FROM $BASE_IMAGE as base
 
 LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"
@@ -61,10 +62,11 @@ ENV RENKU_DISABLE_VERSION_CHECK 1
 
 ENV PATH=$PATH:$HOME/.renku/bin
 
+ARG RENKU_VERSION
 RUN mkdir -p $HOME/.renku/bin && \
-    virtualenv $HOME/.renku/venv && \
+    virtualenv --pip 21.3.1 --setuptools 57.5.0 --wheel 0.36.2  --no-periodic-update $HOME/.renku/venv && \
     source $HOME/.renku/venv/bin/activate && \
-    pip install --no-cache renku sentry-sdk && \
+    pip install --no-cache renku==$RENKU_VERSION sentry-sdk && \
     deactivate && \
     ln -s $HOME/.renku/venv/bin/renku $HOME/.renku/bin/renku
 

--- a/docker/py/requirements.txt
+++ b/docker/py/requirements.txt
@@ -6,4 +6,5 @@ jupyterlab~=3.0.0
 papermill~=2.3.0
 powerline-shell~=0.7.0
 requests>=2.20.0
+setuptools==57.5.0
 virtualenv>=20.7.2

--- a/docker/py/requirements.txt
+++ b/docker/py/requirements.txt
@@ -6,5 +6,4 @@ jupyterlab~=3.0.0
 papermill~=2.3.0
 powerline-shell~=0.7.0
 requests>=2.20.0
-setuptools==57.5.0
 virtualenv>=20.7.2


### PR DESCRIPTION
This bumps the notebooks base image from `lab-3.0.16` to `lab-3.2.1`, so a good look from the @SwissDataScienceCenter/poc squad to check if that breaks something would be appreciated.