### PR TITLE
fix: use renku cli from PATH

### DIFF
--- a/docker/py/entrypoint.sh
+++ b/docker/py/entrypoint.sh
@@ -22,7 +22,7 @@ then
 fi
 
 # install git hooks
-~/.local/bin/renku githooks install || true
+renku githooks install || true
 
 # run the post-init script in the root directory (i.e. coming from the image)
 if [ -f "/post-init.sh" ]; then


### PR DESCRIPTION
After getting rid of pipx, the renku cli executable is in a different location. Therefore, it is not found anymore during the execution of the entrypoint. Since we already make sure that the PATH contains the location of the renku cli, we should omit the exact path to the renku cli executable and instead just use whatever is found in the PATH.