### PR TITLE
chore: remove jupyterhub from base images

### DIFF
--- a/docker/py/requirements.txt
+++ b/docker/py/requirements.txt
@@ -1,5 +1,4 @@
 jupyter-server-proxy~=3.1.0
-jupyterhub~=1.4.0
 jupyterlab-git==0.30.1
 jupyterlab-system-monitor~=0.8.0
 jupyterlab~=3.0.0


### PR DESCRIPTION
JH is not used anymore