### PR TITLE
chore: fix paths for vscode

### DIFF
--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -60,7 +60,7 @@ RUN conda install gxx_linux-64 && \
 # install renku-python
 ENV RENKU_DISABLE_VERSION_CHECK 1
 
-ENV PATH=$PATH:$HOME/.renku/bin
+ENV PATH=$HOME/.local/bin:$PATH:$HOME/.renku/bin
 
 ARG RENKU_VERSION
 RUN mkdir -p $HOME/.renku/bin && \

--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -4,8 +4,9 @@ VSCODE_VERSION=${VSCODE_VERSION:="3.10.2"}
 
 # code-server installation
 mkdir -p ~/.local/lib
+mkdir -p ~/.local/bin
 curl -fL https://github.com/cdr/code-server/releases/download/v${VSCODE_VERSION}/code-server-${VSCODE_VERSION}-linux-amd64.tar.gz \
-  | tar -C ~/.local/lib -xz 
+  | tar -C ~/.local/lib -xz
 mv ~/.local/lib/code-server-${VSCODE_VERSION}-linux-amd64 ~/.local/lib/code-server-${VSCODE_VERSION}
 ln -s ~/.local/lib/code-server-${VSCODE_VERSION}/bin/code-server ~/.local/bin/code-server
 


### PR DESCRIPTION
Our change away from pipx had some unintended consequences on the `PATH` configuration and the existence of certain directories. This PR restores them back to a state that works with the vscode installation script. 