### PR TITLE
chore: do not build bioc-devel

### DIFF
--- a/.github/workflows/build_and_push_to_docker.yml
+++ b/.github/workflows/build_and_push_to_docker.yml
@@ -189,7 +189,7 @@ jobs:
       fail-fast: false
       matrix:
         RELEASES:
-          - devel
+        # - devel --> commented out until issues with RStudio versions are resolved
           - RELEASE_3_11
           - RELEASE_3_12
           # TODO: enable once compatibility issues are fixed - see #154 and #160


### PR DESCRIPTION
We should resolve the deeper issues surrounding RStudio and jupyter-rsession-proxy before trying to push more recent R-based images. 