### PR TITLE
chore: bump default code-server version

### DIFF
--- a/scripts/install-vscode.sh
+++ b/scripts/install-vscode.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VSCODE_VERSION=${VSCODE_VERSION:="3.10.2"}
+VSCODE_VERSION=${VSCODE_VERSION:="3.12.0"}
 
 # code-server installation
 mkdir -p ~/.local/lib


### PR DESCRIPTION
Bumps the default code-server version to `3.12.0`. Verified to work in commit `fb250e753` of https://renkulab.io/projects/rok.roskar/vscode-example