### PR TITLE
chore(ci): update default image in notebooks on release

### DIFF
--- a/.github/workflows/update-default-image-in-notebooks.yml
+++ b/.github/workflows/update-default-image-in-notebooks.yml
@@ -17,10 +17,6 @@ jobs:
     - name: Get image name
       run: |
         echo "NEW_IMAGE=renku/renkulab-py:3.9-${{ env.NEW_VERSION }}" >> $GITHUB_ENV
-    - name: Intall yq
-      run: |
-        sudo wget https://github.com/mikefarah/yq/releases/download/v4.15.1/yq_linux_amd64 -O /usr/bin/yq
-        sudo chmod +x /usr/bin/yq
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -29,7 +25,7 @@ jobs:
         fetch-depth: 1
     - name: Update image version
       run: |
-        yq -i eval '.defaultSessionImage = "${{ env.NEW_IMAGE }}"' ./helm-chart/renku-notebooks/values.yaml
+        sed -e -i 's/defaultSessionImage:.*/defaultSessionImage: ${{ env.NEW_VNEW_IMAGEERSION }}/' ./helm-chart/renku-notebooks/values.yaml
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/update-default-image-in-notebooks.yml
+++ b/.github/workflows/update-default-image-in-notebooks.yml
@@ -21,7 +21,7 @@ jobs:
       run: | 
         # docker pull $NEW_IMAGE || ( echo "Cannot find image $NEW_IMAGE" && exit 1 )
     - name: Intall yq
-      run: apt-get install yq
+      run: sudo apt-get install yq
     - name: Checkout code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/update-default-image-in-notebooks.yml
+++ b/.github/workflows/update-default-image-in-notebooks.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 1
     - name: Update image version
       run: |
-        sed -e -i 's/defaultSessionImage:.*/defaultSessionImage: ${{ env.NEW_VNEW_IMAGEERSION }}/' ./helm-chart/renku-notebooks/values.yaml
+        sed -i -e 's/defaultSessionImage:.*/defaultSessionImage: ${{ env.NEW_VNEW_IMAGEERSION }}/' ./helm-chart/renku-notebooks/values.yaml
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/update-default-image-in-notebooks.yml
+++ b/.github/workflows/update-default-image-in-notebooks.yml
@@ -1,0 +1,44 @@
+name: Update default image in notebooks
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - "*"
+
+jobs:
+  update-notebooks-default-image:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get release tag
+      run: |
+        echo "NEW_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+    - name: Get image name
+      run: |
+        echo "NEW_IMAGE=renku/renkulab-py:3.9-${{ env.NEW_VERSION }}" >> $GITHUB_ENV
+    - name: Check if image exists
+      run: | 
+        docker pull $NEW_IMAGE || ( echo "Cannot find image $NEW_IMAGE" && exit 1 )
+    - name: Intall yq
+      run: apt-get install yq
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        repository: SwissDataScienceCenter/renku-notebooks
+        ref: master
+        fetch-depth: 1
+    - name: Update image version
+      run: |
+        yq eval '.defaultSessionImage = "${{ env.NEW_IMAGE }}"' renku-notebooks/helm-chart/renku-notebooks/values.yaml
+    - name: Submit PR
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.RENKUBOT_GITHUB_TOKEN }}
+        commit-message: "chore(app): Update default session image to ${{ env.NEW_IMAGE }}"
+        title: "chore(app): Update default session image to ${{ env.NEW_IMAGE }}"
+        branch: "chore-update-default-image-${{ env.NEW_VERSION }}"
+        delete-branch: true
+        author: "Renku Bot <renku@datascience.ch>"
+        committer: "Renku Bot <renku@datascience.ch>"
+        body: "Generated automatically on a new release in renkulab-docker to update the default image used when launching a user session."

--- a/.github/workflows/update-default-image-in-notebooks.yml
+++ b/.github/workflows/update-default-image-in-notebooks.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 1
     - name: Update image version
       run: |
-        sed -i -e 's/defaultSessionImage:.*/defaultSessionImage: ${{ env.NEW_VNEW_IMAGEERSION }}/' ./helm-chart/renku-notebooks/values.yaml
+        sed -i -e 's/defaultSessionImage:.*/defaultSessionImage: ${{ env.NEW_IMAGE }}/' ./helm-chart/renku-notebooks/values.yaml
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/update-default-image-in-notebooks.yml
+++ b/.github/workflows/update-default-image-in-notebooks.yml
@@ -19,7 +19,7 @@ jobs:
         echo "NEW_IMAGE=renku/renkulab-py:3.9-${{ env.NEW_VERSION }}" >> $GITHUB_ENV
     - name: Check if image exists
       run: | 
-        docker pull $NEW_IMAGE || ( echo "Cannot find image $NEW_IMAGE" && exit 1 )
+        # docker pull $NEW_IMAGE || ( echo "Cannot find image $NEW_IMAGE" && exit 1 )
     - name: Intall yq
       run: apt-get install yq
     - name: Checkout code

--- a/.github/workflows/update-default-image-in-notebooks.yml
+++ b/.github/workflows/update-default-image-in-notebooks.yml
@@ -17,11 +17,10 @@ jobs:
     - name: Get image name
       run: |
         echo "NEW_IMAGE=renku/renkulab-py:3.9-${{ env.NEW_VERSION }}" >> $GITHUB_ENV
-    - name: Check if image exists
-      run: | 
-        # docker pull $NEW_IMAGE || ( echo "Cannot find image $NEW_IMAGE" && exit 1 )
     - name: Intall yq
-      run: sudo apt-get install yq
+      run: |
+        sudo wget https://github.com/mikefarah/yq/releases/download/v4.15.1/yq_linux_amd64 -O /usr/bin/yq
+        sudo chmod +x /usr/bin/yq
     - name: Checkout code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/update-default-image-in-notebooks.yml
+++ b/.github/workflows/update-default-image-in-notebooks.yml
@@ -3,9 +3,6 @@ name: Update default image in notebooks
 on:
   release:
     types: [published]
-  push:
-    tags:
-      - "*"
 
 jobs:
   update-notebooks-default-image:
@@ -25,7 +22,7 @@ jobs:
         fetch-depth: 1
     - name: Update image version
       run: |
-        sed -i -e 's|defaultSessionImage:.*|defaultSessionImage: ${{ env.NEW_IMAGE }}|' ./helm-chart/renku-notebooks/values.yaml
+        sed -i -e 's|defaultSessionImage:.*|defaultSessionImage: "${{ env.NEW_IMAGE }}"|' ./helm-chart/renku-notebooks/values.yaml
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/update-default-image-in-notebooks.yml
+++ b/.github/workflows/update-default-image-in-notebooks.yml
@@ -29,7 +29,7 @@ jobs:
         fetch-depth: 1
     - name: Update image version
       run: |
-        yq eval '.defaultSessionImage = "${{ env.NEW_IMAGE }}"' ./helm-chart/renku-notebooks/values.yaml
+        yq -i eval '.defaultSessionImage = "${{ env.NEW_IMAGE }}"' ./helm-chart/renku-notebooks/values.yaml
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/update-default-image-in-notebooks.yml
+++ b/.github/workflows/update-default-image-in-notebooks.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 1
     - name: Update image version
       run: |
-        sed -i -e 's/defaultSessionImage:.*/defaultSessionImage: ${{ env.NEW_IMAGE }}/' ./helm-chart/renku-notebooks/values.yaml
+        sed -i -e 's|defaultSessionImage:.*|defaultSessionImage: ${{ env.NEW_IMAGE }}|' ./helm-chart/renku-notebooks/values.yaml
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/update-default-image-in-notebooks.yml
+++ b/.github/workflows/update-default-image-in-notebooks.yml
@@ -29,7 +29,7 @@ jobs:
         fetch-depth: 1
     - name: Update image version
       run: |
-        yq eval '.defaultSessionImage = "${{ env.NEW_IMAGE }}"' renku-notebooks/helm-chart/renku-notebooks/values.yaml
+        yq eval '.defaultSessionImage = "${{ env.NEW_IMAGE }}"' ./helm-chart/renku-notebooks/values.yaml
     - name: Submit PR
       uses: peter-evans/create-pull-request@v3
       with:


### PR DESCRIPTION
Example PR: https://github.com/SwissDataScienceCenter/renku-notebooks/pull/841

p.s. I added the quotation marks in the latest version of the workflow. So the image name is updated with the quotation marks.

closes https://github.com/SwissDataScienceCenter/renku-notebooks/issues/792