### PR TITLE
fix: disable renku cli version check for R

### DIFF
--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -23,7 +23,8 @@ ENV PATH ${HOME}/.local/bin:${CONDA_PATH}/bin:$PATH
 
 # And set PATH for R! It doesn't read from the environment...
 RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron && \
-    echo "PATH=${PATH}" >> /etc/profile.d/set_path.sh
+    echo "PATH=${PATH}" >> /etc/profile.d/set_path.sh && \
+    echo "RENKU_DISABLE_VERSION_CHECK=1" >> /usr/local/lib/R/etc/Renviron
 
 # The `rsession` binary that is called by nbrsessionproxy to start R doesn't seem to start
 # without this being explicitly set


### PR DESCRIPTION
See here for a project that uses the images where the env variable has been added to R:
https://renkulab.io/projects/tasko.olevski/test-new-r-project-1

After this change the `RENKU_DISABLE_VERSION_CHECK=1` env variable shows up in the rstudio terminal.

The images built from this PR can be found in this workflow:
https://github.com/SwissDataScienceCenter/renkulab-docker/actions/runs/1554790636