### PR TITLE
fix: missing cuda library for tensorflow

### DIFF
--- a/docker/cuda-tf/Dockerfile
+++ b/docker/cuda-tf/Dockerfile
@@ -72,6 +72,7 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:$LD
 # Link the libcuda stub to the location where tensorflow is searching for it and reconfigure
 # dynamic linker run-time bindings
 RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 \
+    && ln -s /usr/local/cuda-11.0/targets/x86_64-linux/lib/libcusolver.so.10 /usr/local/cuda-11.0/targets/x86_64-linux/lib/libcusolver.so.11 \
     && echo "/usr/local/cuda/lib64/stubs" > /etc/ld.so.conf.d/z-cuda-stubs.conf \
     && ldconfig
 


### PR DESCRIPTION
So it seems that with CUDA version 11 tensorflow is looking for `libcusolver.so.11`. But there is only `libcusolver.so.10`.

According to [this stackoverflow post](https://stackoverflow.com/questions/63199164/how-to-install-libcusolver-so-11) tensorflow is deriving the name of the `libcusolver` library from the CUDA version.

I tested this on limited here: https://limited.renku.ch/projects/tasko.olevski/test-gpu-1

The first commit in the project will fail to show available GPUs with this:
```python
>>> import tensorflow as tf
>>> print("Num GPUs Available: ", len(tf.config.list_physical_devices('GPU')))
```

However after the linking above the latest commit in the project properly shows that a single GPU is available.

The warning message from tensorflow properly says that it is looking for `libcusolver.so.11` but it cannot find it.