### PR TITLE
feat: add qgis-enabled vnc renku image

### DIFF
--- a/.github/workflows/build_and_push_to_docker.yml
+++ b/.github/workflows/build_and_push_to_docker.yml
@@ -70,7 +70,42 @@ jobs:
       env:
         EXTENSION: ${{ matrix.EXTENSIONS }}
         DOCKER_NAME: "renku/renkulab"
+  
+  build-vnc-ext:
+    needs: build-py-ext
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: true
+      matrix:
+        VNC-EXTENSIONS:
+          - qgis
+    
+    steps:
+    - name: Docker Login
+      uses: Azure/docker-login@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
+    - uses: actions/checkout@v2
+    - name: Build renku project vnc-based docker image for extensions
+      run: |
+        if [[ ${{ github.ref }} == refs/tags* ]]; then
+          export LABEL=$(echo ${{ github.ref }} | cut -d / -f 3)
+        else
+          export LABEL=$(echo ${{ github.sha }} | cut -c 1-7)
+        fi
+
+        docker build docker/$EXTENSION \
+          --build-arg RENKU_BASE="$DOCKER_NAME-vnc:latest" \
+          --tag $DOCKER_NAME-$EXTENSION:$LABEL
+        docker push $DOCKER_NAME-$EXTENSION:$LABEL
+      env:
+        EXTENSION: ${{ matrix.VNC-EXTENSIONS }}
+        DOCKER_NAME: "renku/renkulab"
+    
+  
   build-py-batch:
     needs: build-py
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_push_to_docker.yml
+++ b/.github/workflows/build_and_push_to_docker.yml
@@ -98,7 +98,7 @@ jobs:
         fi
 
         docker build docker/$EXTENSION \
-          --build-arg BASE_IMAGE="$DOCKER_NAME-vnc:latest" \
+          --build-arg BASE_IMAGE="$DOCKER_NAME-vnc:$LABEL" \
           --tag $DOCKER_NAME-$EXTENSION:$LABEL
         docker push $DOCKER_NAME-$EXTENSION:$LABEL
       env:

--- a/.github/workflows/build_and_push_to_docker.yml
+++ b/.github/workflows/build_and_push_to_docker.yml
@@ -98,7 +98,7 @@ jobs:
         fi
 
         docker build docker/$EXTENSION \
-          --build-arg RENKU_BASE="$DOCKER_NAME-vnc:latest" \
+          --build-arg BASE_IMAGE="$DOCKER_NAME-vnc:latest" \
           --tag $DOCKER_NAME-$EXTENSION:$LABEL
         docker push $DOCKER_NAME-$EXTENSION:$LABEL
       env:

--- a/docker/qgis/Dockerfile
+++ b/docker/qgis/Dockerfile
@@ -1,7 +1,7 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-vnc:latest
-FROM ${RENKU_BASE_IMAGE}
+ARG BASE_IMAGE=renku/renkulab-vnc:latest
+FROM ${BASE_IMAGE}
 
 USER root
 

--- a/docker/qgis/Dockerfile
+++ b/docker/qgis/Dockerfile
@@ -1,0 +1,40 @@
+# For finding latest versions of the base image see
+# https://github.com/SwissDataScienceCenter/renkulab-docker
+ARG RENKU_BASE_IMAGE=renku/renkulab-vnc:latest
+FROM ${RENKU_BASE_IMAGE}
+
+USER root
+
+# Install qGIS
+RUN apt-get update \
+    && apt-get install -y -q --no-install-recommends \
+        gnupg \
+        software-properties-common \
+        libqt5gui5 \
+    && apt-get autoremove --purge \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/*
+
+RUN wget -qO - https://qgis.org/downloads/qgis-2021.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import \
+    && chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
+
+RUN add-apt-repository "deb https://qgis.org/ubuntu $(lsb_release -c -s) main"
+
+# Fixes a bug https://github.com/qgis/QGIS/issues/35649 and removes qgis-providers which may be a problem
+# RUN apt-get remove --auto-remove libproj15 libproj-dev qgis-providers
+
+# Fixes downstream bug with libQt5Core.so.5
+RUN strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
+
+RUN apt-get update \
+    && apt-get install -y -q --no-install-recommends \
+        qgis 
+        
+COPY --chown=root:root qgis.desktop /home/jovyan/Desktop/
+RUN chmod +x /home/jovyan/Desktop/qgis.desktop
+
+USER ${NB_USER}
+
+# install the python dependencies
+RUN conda install -c conda-forge qgis

--- a/docker/qgis/Dockerfile
+++ b/docker/qgis/Dockerfile
@@ -5,32 +5,27 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-# Install qGIS
+# Install QGIS
 RUN apt-get update \
     && apt-get install -y -q --no-install-recommends \
         gnupg \
         software-properties-common \
         libqt5gui5 \
+    && wget -qO - https://qgis.org/downloads/qgis-2021.gpg.key | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import \
+    && chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg \
+    && add-apt-repository "deb https://qgis.org/ubuntu $(lsb_release -c -s) main" \
+    && apt-get update \
+    && apt-get install -y -q --no-install-recommends \
+        qgis \
     && apt-get autoremove --purge \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/*
 
-RUN wget -qO - https://qgis.org/downloads/qgis-2021.gpg.key | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import \
-    && chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
-
-RUN add-apt-repository "deb https://qgis.org/ubuntu $(lsb_release -c -s) main"
-
-# Fixes a bug https://github.com/qgis/QGIS/issues/35649 and removes qgis-providers which may be a problem
-# RUN apt-get remove --auto-remove libproj15 libproj-dev qgis-providers
-
 # Fixes downstream bug with libQt5Core.so.5
 RUN strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
 
-RUN apt-get update \
-    && apt-get install -y -q --no-install-recommends \
-        qgis 
-        
+# Add desktop icon for QGIS
 COPY --chown=root:root qgis.desktop /home/jovyan/Desktop/
 RUN chmod +x /home/jovyan/Desktop/qgis.desktop
 

--- a/docker/qgis/Dockerfile
+++ b/docker/qgis/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/*
 
-RUN wget -qO - https://qgis.org/downloads/qgis-2021.gpg.key | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import \
+RUN wget -qO - https://qgis.org/downloads/qgis-2021.gpg.key | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/qgis-archive.gpg --import \
     && chmod a+r /etc/apt/trusted.gpg.d/qgis-archive.gpg
 
 RUN add-apt-repository "deb https://qgis.org/ubuntu $(lsb_release -c -s) main"

--- a/docker/qgis/qgis.desktop
+++ b/docker/qgis/qgis.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Version=3.18
+Name=QGIS
+GenericName=QGIS
+X-GNOME-FullName=QGIS
+Comment=Geographic Information System Application
+Type=Application
+Categories=Geography;Science;Geospatial;
+Exec=/opt/conda/bin/qgis
+TryExec=/opt/conda/bin/qgis
+Terminal=false
+StartupNotify=true
+Icon=/usr/share/qgis/images/icons/qgis-icon-60x60.png
+StartupWMClass=QGIS-main


### PR DESCRIPTION
Due to demand from earth & environmental sciences, we have enabled QGIS to run as a GUI application on the Renku VNC.