### PR TITLE
chore: bump rp because 1.0.4 is potentially buggy

### DIFF
--- a/docker/batch/Dockerfile
+++ b/docker/batch/Dockerfile
@@ -1,7 +1,7 @@
 # define build arguments
 ARG RENKU_BASE=renku/renkulab-py:latest
 ARG BASE_IMAGE=python:3.9-slim-buster
-ARG RENKU_VERSION=1.0.4
+ARG RENKU_VERSION=1.0.5
 
 # define base images
 FROM $RENKU_BASE as renku_base

--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=jupyter/base-notebook:lab-3.2.1
-ARG RENKU_VERSION=1.0.4
+ARG RENKU_VERSION=1.0.5
 FROM $BASE_IMAGE as base
 
 LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"


### PR DESCRIPTION
Bump the rp version again because 1.0.4 has some dependency resolution issues. 