### PR TITLE
fix: add renku cli to PATH in rstudio

### DIFF
--- a/.github/workflows/build_and_push_to_docker.yml
+++ b/.github/workflows/build_and_push_to_docker.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Docker Login
       uses: Azure/docker-login@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+        password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
 
     - uses: actions/checkout@v2
     - name: Build renku project python-based docker images
@@ -78,8 +78,8 @@ jobs:
     - name: Docker Login
       uses: Azure/docker-login@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+        password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
 
     - uses: actions/checkout@v2
     - name: Build renku project python-based docker image extensions
@@ -147,8 +147,8 @@ jobs:
     - name: Docker Login
       uses: Azure/docker-login@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+        password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
 
     - uses: actions/checkout@v2
     - name: Build renku project python-based docker image extensions
@@ -207,8 +207,8 @@ jobs:
     - name: Docker Login
       uses: Azure/docker-login@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+        password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
 
     - uses: actions/checkout@v2
     - name: Build renku project python-based docker image extensions
@@ -254,8 +254,8 @@ jobs:
     - name: Docker Login
       uses: Azure/docker-login@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+        password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
 
     - uses: actions/checkout@v2
     - name: Build renku project python-based docker image extensions
@@ -282,8 +282,8 @@ jobs:
     - name: Docker Login
       uses: Azure/docker-login@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+        password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
 
     - uses: actions/checkout@v2
     - name: Build renku project python-based docker image for batch execution
@@ -316,8 +316,8 @@ jobs:
     - name: Docker Login
       uses: Azure/docker-login@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+        password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
 
     - uses: actions/checkout@v2
     - name: Build renku project julia docker image extensions
@@ -362,8 +362,8 @@ jobs:
     - name: Docker Login
       uses: Azure/docker-login@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+        password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
 
     - uses: actions/checkout@v2
     - name: Build renku project rocker docker images
@@ -416,8 +416,8 @@ jobs:
     - name: Docker Login
       uses: Azure/docker-login@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.RENKU_DOCKER_USERNAME }}
+        password: ${{ secrets.RENKU_DOCKER_PASSWORD }}
 
     - uses: actions/checkout@v2
     - name: Build renku project bioconductor docker images

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -20,7 +20,7 @@ ENV CONDA_PATH /opt/conda
 SHELL [ "/bin/bash", "-c" ]
 
 # prepend conda and local/bin to PATH
-ENV PATH ${HOME}/.local/bin:${CONDA_PATH}/bin:$PATH
+ENV PATH ${HOME}/.local/bin:${CONDA_PATH}/bin:${HOME}/.renku/bin:$PATH
 
 # And set PATH for R! It doesn't read from the environment...
 RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron.site && \


### PR DESCRIPTION
Fixes renku not being present in the PATH of rstudio images.