### PR TITLE
fix: R image builds

### DIFF
--- a/.github/workflows/build_and_push_to_docker.yml
+++ b/.github/workflows/build_and_push_to_docker.yml
@@ -353,12 +353,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        RVERSION:
-          - 4.1.0
-          - 4.1.1
-          - 4.1.2
-          - 4.2.0
-          - devel
+        include:
+          - RVERSION: 4.1.0
+            RSTUDIO_VERSION: 2021.09.2-382
+          - RVERSION: 4.1.1
+            RSTUDIO_VERSION: 2021.09.2-382
+          - RVERSION: 4.1.2
+            RSTUDIO_VERSION: 2021.09.2-382
+          - RVERSION: 4.2.0
+            RSTUDIO_VERSION: 2021.09.2-382
+          - RVERSION: devel
+            RSTUDIO_VERSION: 2022.02.3-492
     steps:
     - name: Docker Login
       uses: Azure/docker-login@v1
@@ -380,6 +385,7 @@ jobs:
         docker build docker/r \
           --build-arg RENKU_BASE="$DOCKER_NAME-py:3.9-$LABEL" \
           --build-arg BASE_IMAGE="rocker/verse:${{ matrix.RVERSION }}" \
+          --build-arg RSTUDIO_VERSION_OVERRIDE="${{ matrix.RSTUDIO_VERSION }}" \
           --tag $DOCKER_NAME-r:$DOCKER_TAG
         
         echo "::set-output name=IMAGE_NAME::$DOCKER_NAME-r:$DOCKER_TAG"

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -1,6 +1,6 @@
 # define build arguments
-ARG RENKU_BASE=renku/renkulab-py:latest
-ARG BASE_IMAGE=rocker/verse:4.2.0
+ARG RENKU_BASE=renku/renkulab-py:3.9-d7394dd
+ARG BASE_IMAGE=rocker/verse:devel
 
 # define base images
 FROM $RENKU_BASE as renku_base
@@ -32,7 +32,7 @@ RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron.site && \
 ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
 
 # pin the version of RStudio
-ARG RSTUDIO_VERSION_OVERRIDE="2021.09.2-382"
+ARG RSTUDIO_VERSION_OVERRIDE="2022.02.3-492"
 ENV RSTUDIO_VERSION=${RSTUDIO_VERSION_OVERRIDE}
 # if rstudio and rstudio-server users are not deleted below, the installation
 # script fails when it installs rstudio and tries to add them back in
@@ -52,7 +52,8 @@ RUN apt-get update --fix-missing && \
     ca-certificates \
     curl \
     gpg-agent && \
-    curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+    apt-get remove -y libnode-dev libnode72:amd64 || echo "Conflicting libraries do not exist, continuing..." && \
+    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
     apt-get update && \
     apt-get install -yq --no-install-recommends \


### PR DESCRIPTION
The reason for this is that the rocker/verse:devel image has switched to ubuntu 22.04 (jammy) but the rstudio .deb installer is only available for focal and older versions. The rstudio installation script builds the url from the ubuntu version and it just fails.

The rstudio version that is available for ubuntu 22.04 is `2022.02.3-492`. So I have switched the ci pipeline to use that for the devel image.

I will test if this work with renku.