### PR TITLE
chore: update git LFS to 3.2.0 for python images

### DIFF
--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
     apt-get update && apt-get install -yq --no-install-recommends \
     git \
-    git-lfs=2.12.0 \
+    git-lfs=3.2.0 \
     gnupg \
     graphviz \
     jq \


### PR DESCRIPTION
The really old git lfs version is actually not working on the BIT deployment. But updating to a newer version works without a problem.

Even if this was not the case using a newer version of git LFS is a good idea.