### PR TITLE
chore: enable dependabot updates on python libs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   directory: "/docker/py"
   schedule:
     interval: daily
-  open-pull-request-limit: 10
+  open-pull-requests-limit: 10
 - package-ecosystem: docker
   directory: "/docker/r"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     time: "04:00"
   open-pull-requests-limit: 10
 - package-ecosystem: "pip"
-  directory: "/docker/requirements.txt"
+  directory: "/docker/py/requirements.txt"
   schedule:
     interval: daily
   open-pull-request-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     time: "04:00"
   open-pull-requests-limit: 10
 - package-ecosystem: "pip"
-  directory: "/docker/py/requirements.txt"
+  directory: "/docker/py"
   schedule:
     interval: daily
   open-pull-request-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
+- package-ecosystem: "pip"
+  directory: "/docker/requirements.txt"
+  schedule:
+    interval: daily
+  open-pull-request-limit: 10
 - package-ecosystem: docker
   directory: "/docker/r"
   schedule:


### PR DESCRIPTION
Let dependabot update the requirements.txt for the base python image