### PR TITLE
fix: cuda-tf image builds

### DIFF
--- a/docker/cuda-tf/Dockerfile
+++ b/docker/cuda-tf/Dockerfile
@@ -20,4 +20,6 @@ SHELL ["/bin/bash", "-c"]
 USER $NB_USER
 ARG TF_PACKAGE=tensorflow-gpu
 ARG TF_PACKAGE_VERSION=2.5.0
-RUN python3 -m pip install --no-cache-dir ${TF_PACKAGE}${TF_PACKAGE_VERSION:+==${TF_PACKAGE_VERSION}}
+# Jupyter needs 'soft_unicode' from 'markupsafe' but 'soft_unicode' was
+# removed in versions of marksupsafe after 2.0.1
+RUN python3 -m pip install --no-cache-dir markupsafe==2.0.1 ${TF_PACKAGE}${TF_PACKAGE_VERSION:+==${TF_PACKAGE_VERSION}}


### PR DESCRIPTION
The failing acceptance tests for `cuda-tf` image are caused because the jupyter server cannot start because of this:

```
Traceback (most recent call last):
  File "/opt/conda/bin/jupyter-lab", line 6, in <module>
    from jupyterlab.labapp import main
  File "/opt/conda/lib/python3.8/site-packages/jupyterlab/__init__.py", line 7, in <module>
    from .labapp import LabApp
  File "/opt/conda/lib/python3.8/site-packages/jupyterlab/labapp.py", line 15, in <module>
    from jupyterlab_server import slugify, WORKSPACE_EXTENSION
  File "/opt/conda/lib/python3.8/site-packages/jupyterlab_server/__init__.py", line 4, in <module>
    from .app import LabServerApp
  File "/opt/conda/lib/python3.8/site-packages/jupyterlab_server/app.py", line 7, in <module>
    from jupyter_server.extension.application import ExtensionApp, ExtensionAppJinjaMixin
  File "/opt/conda/lib/python3.8/site-packages/jupyter_server/extension/application.py", line 5, in <module>
    from jinja2 import Environment, FileSystemLoader
  File "/opt/conda/lib/python3.8/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/opt/conda/lib/python3.8/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/opt/conda/lib/python3.8/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/opt/conda/lib/python3.8/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/opt/conda/lib/python3.8/site-packages/markupsafe/__init__.py)
```

I suspect that tensorflow (or some other python package that is only used in this image) is updating thie `markupsafe` package to a newer version that is missing `soft_unicode`. 

According to the markupsafe [changelog](https://markupsafe.palletsprojects.com/en/2.1.x/changes/?highlight=soft_unicode#version-2-1-0) `soft_unicode` was removed after version 2.0.1.