### PR TITLE
fix: broken nbconvert package

### DIFF
--- a/docker/py/requirements.txt
+++ b/docker/py/requirements.txt
@@ -6,3 +6,4 @@ powerline-shell~=0.7.0
 requests>=2.20.0
 virtualenv>=20.7.2
 mistune>=2.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
+Jinja2<3.1 # because of https://github.com/jupyter/nbconvert/issues/1742


### PR DESCRIPTION
This was causing a lot of warnings in the console and making certain features of sessions buggy/unstable.

For example converting a notebook into anything would fail.

But also the notebooks and the jupyter server uses nbconver (for some reason) while it runs.

Example of failed client calls with our latest version:
![image](https://user-images.githubusercontent.com/16360283/197739646-3a5871b4-2c70-45c1-93e5-b0e55f53edaa.png)

Also failures such as this show up in the browser console:
![image](https://user-images.githubusercontent.com/16360283/197740606-5b84debd-6532-4323-9aea-ef184a597043.png)

With the update there are no such failed requests and the console has only warnings.

Here is a project that has the image from this PR pinned in its latest commit. In the first commit the older image that has issues is used.

There is an option to enable cypress to fail when there are any failures in the console. That would have caught this problem. I will enable it in a separate PR.

