### PR TITLE
chore: simplify dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,8 +45,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 5
-- package-ecosystem: "pip"
-  directory: "/docker/py/renku-requirements"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 5


### PR DESCRIPTION
It looks like the single dependabot spec pics up requirements files in all subdirectories.