### PR TITLE
chore: bump jupyter base image

### DIFF
--- a/.github/workflows/build-and-push-to-docker.yml
+++ b/.github/workflows/build-and-push-to-docker.yml
@@ -59,8 +59,8 @@ jobs:
       fail-fast: true
       matrix:
         BASE_IMAGE_TAG:
-          - lab-3.4.0
-          - python-3.10.6
+          - lab-3.6.1
+          - python-3.10.9
           - python-3.9.12
           - python-3.8.13
 
@@ -85,7 +85,7 @@ jobs:
 
         # This ensures the same image tags as before are built, in addition to new ones
         if [[ "${{ matrix.BASE_IMAGE_TAG }}" == lab-* ]]; then
-          export RENKU_PYTHON_BASE_IMAGE_TAG=3.9
+          export RENKU_PYTHON_BASE_IMAGE_TAG=3.10
         else
           export RENKU_PYTHON_BASE_IMAGE_TAG=${{ matrix.BASE_IMAGE_TAG }}
         fi

--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=jupyter/base-notebook:lab-3.4.0
+ARG BASE_IMAGE=jupyter/base-notebook:python-3.10.9
 FROM $BASE_IMAGE as base
 
 LABEL maintainer="Swiss Data Science Center <info@datascience.ch>"


### PR DESCRIPTION
Bumps base image. Makes the change to python 3.10. 