### PR TITLE
chore: override notebook command

### DIFF
--- a/docker/py/entrypoint.sh
+++ b/docker/py/entrypoint.sh
@@ -45,5 +45,16 @@ fi
 # Start the SHH daemon in the background
 /usr/sbin/sshd -f /opt/ssh/sshd_config -E /tmp/sshd.log
 
+# Override the jupyter command to be forward compatible with newer
+# images that no longer launch the whole server with `jupyter notebook`.
+jupyter() { 
+    if [ "$1" = "notebook" ]; 
+    then 
+        shift  
+        $(which jupyter) server $@; 
+    else $(which jupyter) $@; 
+    fi; 
+}
+
 # run the command
 $@


### PR DESCRIPTION
This PR injects a function into the entrypoint to override the jupyter command so that it can be forward compatible with newer images that no longer start the full server with `jupyter notebook`, making `/lab` yield a 404. 