### PR TITLE
chore: ensure correct PATH on ssh

### DIFF
--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -14,9 +14,6 @@ USER $NB_USER
 COPY requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install --no-cache-dir -U pip && \
     python3 -m pip install --no-cache-dir -r /tmp/requirements.txt && \
-    # jupyter lab build && \
-    # jupyter labextension list && \
-    # npm cache clean --force && \
     rm -rf "/home/${NB_USER}/.cache"
 
 # jupyter sets channel priority to strict which often causes very long error messages
@@ -75,20 +72,11 @@ RUN mkdir -p "$HOME/.ssh" && \
     touch "$HOME/.ssh/authorized_keys" && \
     chmod u=rw,g=,o= "$HOME/.ssh/authorized_keys"
 
-# install renku-python
-ENV RENKU_DISABLE_VERSION_CHECK 1
-
+# configure bash and shell prompt
 ENV PATH=$HOME/.local/bin:$PATH:$HOME/.renku/bin
-
-# configure git
-COPY git-config.bashrc /home/$NB_USER/
-RUN cat "/home/$NB_USER/git-config.bashrc" >> "/home/$NB_USER/.bashrc" && rm "/home/$NB_USER/git-config.bashrc"
-
-# configure powerline
-COPY --chown=1000:100 powerline.bashrc /tmp/powerline.bashrc
+COPY --chown=1000:100 bashrc /renku/
 COPY --chown=1000:100 powerline.config /home/${NB_USER}/.config/powerline-shell/config.json
-
-RUN cat /tmp/powerline.bashrc >> ~/.bashrc && rm /tmp/powerline.bashrc
+RUN cat "/renku/bashrc" >> "${HOME}/.bashrc" 
 
 COPY entrypoint.sh /entrypoint.sh
 
@@ -108,7 +96,7 @@ RUN chown -R 0:100 /opt/ssh/ && \
 
 ENTRYPOINT [ "tini", "--", "/entrypoint.sh" ]
 
-CMD [ "/usr/local/bin/start-singleuser.sh" ]
+CMD [ "jupyter", "server", "--ip", "0.0.0.0" ]
 
 USER $NB_USER
 COPY --chown=1000:100 --from=builder /opt/conda /opt/conda

--- a/docker/py/bashrc
+++ b/docker/py/bashrc
@@ -1,0 +1,23 @@
+# if this is an ssh shell, set PATH
+if [ -n "$SSH_TTY" ]; then
+    export PATH=/opt/conda/bin:/opt/conda/condabin:$HOME/.local/bin:$PATH:$HOME/.renku/bin
+    eval "$(command conda shell.bash hook 2> /dev/null)"
+fi
+
+# Setup git user
+if [[ -z "$(git config --global --get user.name)" && -v GIT_AUTHOR_NAME ]]; then
+    git config --global user.name "$GIT_AUTHOR_NAME"
+fi
+if [[ -z "$(git config --global --get user.email)" && -v EMAIL ]]; then
+    git config --global user.email "$EMAIL"
+fi
+
+function _update_ps1() {
+    PS1=$(powerline-shell $?)
+}
+
+if [[ $TERM != linux && ! $PROMPT_COMMAND =~ _update_ps1 ]]; then
+    PROMPT_COMMAND="_update_ps1; $PROMPT_COMMAND"
+fi
+
+export RENKU_DISABLE_VERSION_CHECK=1

--- a/docker/py/entrypoint.sh
+++ b/docker/py/entrypoint.sh
@@ -22,7 +22,7 @@ then
 fi
 
 # install git hooks
-renku githooks install || true
+renku githooks install > /dev/null 2>&1 || true 
 
 # run the post-init script in the root directory (i.e. coming from the image)
 if [ -f "/post-init.sh" ]; then

--- a/docker/py/git-config.bashrc
+++ b/docker/py/git-config.bashrc
@@ -1,8 +1,0 @@
-
-# Setup git user
-if [[ -z "$(git config --global --get user.name)" && -v GIT_AUTHOR_NAME ]]; then
-    git config --global user.name "$GIT_AUTHOR_NAME"
-fi
-if [[ -z "$(git config --global --get user.email)" && -v EMAIL ]]; then
-    git config --global user.email "$EMAIL"
-fi

--- a/docker/py/powerline.bashrc
+++ b/docker/py/powerline.bashrc
@@ -1,7 +1,0 @@
-function _update_ps1() {
-    PS1=$(powerline-shell $?)
-}
-
-if [[ $TERM != linux && ! $PROMPT_COMMAND =~ _update_ps1 ]]; then
-    PROMPT_COMMAND="_update_ps1; $PROMPT_COMMAND"
-fi

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -77,10 +77,10 @@ RUN apt-get update --fix-missing && \
 
 # inject the renku-jupyter stack
 COPY --from=renku_base /opt/conda /opt/conda
-COPY --from=renku_base --chown=rstudio:rstudio  /usr/local/bin/ /usr/local/bin/
-COPY --from=renku_base --chown=rstudio:rstudio \
-    /home/jovyan/ /home/rstudio/
+COPY --from=renku_base --chown=rstudio:rstudio /usr/local/bin/ /usr/local/bin/
+COPY --from=renku_base --chown=rstudio:rstudio /home/jovyan/ /home/rstudio/
 COPY --from=renku_base /entrypoint.sh /entrypoint.sh
+COPY --from=renku_base /renku/bashrc /renku/bashrc
 
 # set permissions of the R library directory to be editable by NB_USER
 COPY fix-permissions.sh /usr/local/bin
@@ -98,7 +98,9 @@ USER ${NB_USER}
 
 # set up conda in the NB_USER environment
 RUN echo ". ${CONDA_PATH}/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    echo "conda activate base" >> ~/.bashrc
+    echo "conda activate base" >> ~/.bashrc && \
+    cat /renku/bashrc >> $HOME/.bashrc && \
+    echo "source ~/.bashrc" >> ~/.bash_profile
 
 RUN pip install --no-cache-dir "jupyter-rsession-proxy==2.0.1"
 
@@ -106,10 +108,8 @@ RUN pip install --no-cache-dir "jupyter-rsession-proxy==2.0.1"
 RUN R --quiet -e "install.packages('IRkernel')" && \
     R --quiet -e "IRkernel::installspec(prefix='${CONDA_PATH}')"
 
-RUN  echo "source ~/.bashrc" >> ~/.bash_profile
-
 COPY post-init.sh /post-init.sh
 ENTRYPOINT [ "/tini", "--", "/entrypoint.sh" ]
-CMD [ "jupyterhub-singleuser" ]
+CMD [ "jupyter", "server", "--ip", "0.0.0.0" ]
 
 WORKDIR ${HOME}


### PR DESCRIPTION
`PATH` was set in some places via environment, which means it was not set on SSH. This PR fixes the problem. 

To reproduce the original issue, run a session with the `renku/renkulab-py:3.10-0.15.1` image and ssh into the session - it will fail because the `powerline-shell` is not found. 