### PR TITLE
chore: do not add provenance metadata to images

### DIFF
--- a/.github/workflows/build-and-push-to-docker.yml
+++ b/.github/workflows/build-and-push-to-docker.yml
@@ -155,6 +155,7 @@ jobs:
         build-args: |
           BASE_IMAGE=jupyter/base-notebook:python-${{ matrix.BASE_PYTHON_VERSION }}   
         platforms: linux/amd64,linux/arm64
+        provenance: false
 
   build-cuda:
     needs: build-py


### PR DESCRIPTION
Encoding provenance metadata in images seems to cause problems for many common docker libraries. See [here](https://community.fly.io/t/images-built-with-the-latest-docker-buildx-and-or-github-actions-work-again/10816) for an explanation. 