### PR TITLE
chore: put toil execs on the path

### DIFF
--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -101,4 +101,5 @@ CMD [ "jupyter", "server", "--ip", "0.0.0.0" ]
 USER $NB_USER
 COPY --chown=1000:100 --from=builder /opt/conda /opt/conda
 COPY --chown=1000:100 --from=builder "$HOME/.renku" "$HOME/.renku"
-RUN ln -s "$HOME/.renku/venv/bin/renku" "$HOME/.renku/bin/renku"
+RUN ln -s "$HOME/.renku/venv/bin/renku" "$HOME/.renku/bin/renku" && \
+    ln -s "$HOME/.renku/venv/bin/*toil*" "$HOME/.renku/bin/"

--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -102,4 +102,4 @@ USER $NB_USER
 COPY --chown=1000:100 --from=builder /opt/conda /opt/conda
 COPY --chown=1000:100 --from=builder "$HOME/.renku" "$HOME/.renku"
 RUN ln -s "$HOME/.renku/venv/bin/renku" "$HOME/.renku/bin/renku" && \
-    ln -s "$HOME/.renku/venv/bin/*toil*" "$HOME/.renku/bin/"
+    ln -s "$HOME/.renku/venv/bin/_toil_worker" "$HOME/.renku/bin/"


### PR DESCRIPTION
Make sure the toil executables are in a directory that is on `PATH`

You can verify that this fixes the problem by [starting this session](https://renkulab.io/projects/rok.roskar/flights-tutorial-current/sessions/new?autostart=1), then doing `renku update --all`. It should update without errors. 