### PR TITLE
chore: R & RStudio to latest rocker with CRAN snapshot

### DIFF
--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -1,6 +1,6 @@
 # define build arguments
 ARG RENKU_BASE=renku/renkulab-py:latest
-ARG BASE_IMAGE=rocker/verse:devel
+ARG BASE_IMAGE=rocker/verse:4.3.0
 
 # define base images
 FROM $RENKU_BASE as renku_base
@@ -32,7 +32,7 @@ RUN echo "PATH=${PATH}" >> /usr/local/lib/R/etc/Renviron.site && \
 ENV LD_LIBRARY_PATH /usr/local/lib/R/lib
 
 # pin the version of RStudio
-ARG RSTUDIO_VERSION_OVERRIDE="2022.02.3-492"
+ARG RSTUDIO_VERSION_OVERRIDE="2023.06.0-421"
 ENV RSTUDIO_VERSION=${RSTUDIO_VERSION_OVERRIDE}
 # if rstudio and rstudio-server users are not deleted below, the installation
 # script fails when it installs rstudio and tries to add them back in


### PR DESCRIPTION
The RStudio, R & Quarto versions in the default R 4.2.0 image are getting a little old now, especially the quarto version which is moving quite fast.

I tested a project based on an image built with these changes using the default R project template and it seems to work perfectly fine.

rocker/verse:devel gives R version 4.4.0 which is still the development version rather than the latest stable release so I switched it to 4.3.0 for verse and 2023.06.0-421 based on the latest versions from rocker https://github.com/rocker-org/rocker-versioned2/wiki/Versions for which there is a CRAN snapshot. That way other R package installs should have fixed versions based on that CRAN snapshot by default.