### PR TITLE
chore(ci): publish tagged homedir env images

### DIFF
--- a/.github/workflows/build-and-push-to-docker.yml
+++ b/.github/workflows/build-and-push-to-docker.yml
@@ -143,6 +143,8 @@ jobs:
         images: ${{ env.DOCKER_PREFIX }}-py-homedir-envs
         tags: |
           type=sha,prefix=${{ matrix.BASE_PYTHON_VERSION }}-
+          type=semver,pattern={{version}},prefix=${{ matrix.BASE_PYTHON_VERSION }}-
+          type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && matrix.BASE_PYTHON_VERSION == env.DEFAULT_PYTHON_VERSION }} 
     - name: Build and load
       uses: docker/build-push-action@v5
       with:

--- a/docker/py/Dockerfile
+++ b/docker/py/Dockerfile
@@ -105,5 +105,6 @@ COPY --chown=1000:100 --from=builder /opt/conda /opt/conda
 COPY --chown=1000:100 --from=builder "$HOME/.renku" "$HOME/.renku"
 RUN ln -s "$HOME/.renku/venv/bin/renku" "$HOME/.renku/bin/renku" && \
     ln -s "$HOME/.renku/venv/bin/_toil_worker" "$HOME/.renku/bin/"
-ARG CONDA_ENVS_DIRS=/opt/conda/envs
-ENV CONDA_ENVS_DIRS=${CONDA_ENVS_DIRS}
+
+ARG CONDA_ENVS_DIRS
+ENV CONDA_ENVS_DIRS=${CONDA_ENVS_DIRS:-/opt/conda/envs}


### PR DESCRIPTION
Prior to this homedir python environment images were not tagged with latest or with the git tag.