### PR TITLE
chore: remove sentry-sdk from the base image

### DIFF
--- a/docker/py/renku-requirements/requirements.txt
+++ b/docker/py/renku-requirements/requirements.txt
@@ -1,5 +1,4 @@
 renku==2.8.0
 pip==23.3.2
-sentry-sdk==1.40.5
 setuptools>=65.5.1
 wheel==0.42.0


### PR DESCRIPTION
Pinning this in the requirements here tends to not allow renku CLI to get updated. We don't really use it or need it in the base image, so it's better to remove the extra dependency anyway. 